### PR TITLE
Make api independent of converter-api

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 }
 
 dependencies {
-    api(project(":converter-api"))
+
 }

--- a/api/src/main/kotlin/io/mcarle/konvert/api/Konfig.kt
+++ b/api/src/main/kotlin/io/mcarle/konvert/api/Konfig.kt
@@ -2,7 +2,13 @@ package io.mcarle.konvert.api
 
 @Retention(AnnotationRetention.SOURCE)
 annotation class Konfig(
+    /**
+     * Name/Key of an option. See in package [io.mcarle.konvert.api.config] for a list of options.
+     */
     val key: String,
+    /**
+     * Value for the defined option
+     */
     val value: String
 ) {
     companion object

--- a/api/src/main/kotlin/io/mcarle/konvert/api/Konvert.kt
+++ b/api/src/main/kotlin/io/mcarle/konvert/api/Konvert.kt
@@ -1,7 +1,5 @@
 package io.mcarle.konvert.api
 
-import io.mcarle.konvert.converter.api.DEFAULT_KONVERT_PRIORITY
-import io.mcarle.konvert.converter.api.Priority
 import kotlin.reflect.KClass
 
 @Retention(AnnotationRetention.SOURCE)

--- a/api/src/main/kotlin/io/mcarle/konvert/api/KonvertFrom.kt
+++ b/api/src/main/kotlin/io/mcarle/konvert/api/KonvertFrom.kt
@@ -1,7 +1,5 @@
 package io.mcarle.konvert.api
 
-import io.mcarle.konvert.converter.api.DEFAULT_KONVERT_FROM_PRIORITY
-import io.mcarle.konvert.converter.api.Priority
 import kotlin.reflect.KClass
 
 /**

--- a/api/src/main/kotlin/io/mcarle/konvert/api/KonvertTo.kt
+++ b/api/src/main/kotlin/io/mcarle/konvert/api/KonvertTo.kt
@@ -1,7 +1,5 @@
 package io.mcarle.konvert.api
 
-import io.mcarle.konvert.converter.api.DEFAULT_KONVERT_TO_PRIORITY
-import io.mcarle.konvert.converter.api.Priority
 import kotlin.reflect.KClass
 
 /**

--- a/api/src/main/kotlin/io/mcarle/konvert/api/Mapping.kt
+++ b/api/src/main/kotlin/io/mcarle/konvert/api/Mapping.kt
@@ -1,8 +1,5 @@
 package io.mcarle.konvert.api
 
-import io.mcarle.konvert.converter.api.TypeConverter
-import kotlin.reflect.KClass
-
 /**
  * Describe how the value for [target] field should be determined. Rules are applied in following order:
  * * if [ignore] is set the target value is not mandatory, skip the field
@@ -87,17 +84,21 @@ annotation class Mapping(
      * With this setting, you can enable them for this specific mapping.
      * ```kotlin
      * @KonvertTo(PersonDto::class, mappings=[
-     *      Mapping(target="age", enable=[StringToIntConverter::class])
+     *      Mapping(target="age", enable=[STRING_TO_INT_CONVERTER])
      * ])
      * class Person(val age: String)
      * class PersonDto(val age: Int)
      * ```
+     *
+     * See in package [io.mcarle.konvert.api.converter] for a list of provided type converter names
      */
-    val enable: Array<KClass<out TypeConverter>> = []
+    val enable: Array<TypeConverterName> = []
 
 ) {
     companion object
 }
+
+typealias TypeConverterName = String
 
 /**
  * Throws exceptions when no params (beside [Mapping.target]) are defined or an illegal parameter combination is defined.

--- a/api/src/main/kotlin/io/mcarle/konvert/api/Priority.kt
+++ b/api/src/main/kotlin/io/mcarle/konvert/api/Priority.kt
@@ -1,4 +1,4 @@
-package io.mcarle.konvert.converter.api
+package io.mcarle.konvert.api
 
 typealias Priority = Int
 

--- a/api/src/main/kotlin/io/mcarle/konvert/api/config/names.kt
+++ b/api/src/main/kotlin/io/mcarle/konvert/api/config/names.kt
@@ -1,0 +1,17 @@
+package io.mcarle.konvert.api.config
+
+/**
+ * Special handling for the case, that the source type is nullable and target type is not nullable:
+ * When enabled, the converters will use the not-null assertion operator to enforce the mapped value to be non-null.
+ * Otherwise, the converters should not match.
+ *
+ * Default: false
+ */
+const val ENFORCE_NOT_NULL = "konvert.enforce-not-null"
+
+/**
+ * When set to true, a class instead of an object is being generated during processing of @[io.mcarle.konvert.api.Konverter]
+ *
+ * Default: false
+ */
+const val KONVERTER_GENERATE_CLASS = "konvert.konverter.generate-class"

--- a/api/src/main/kotlin/io/mcarle/konvert/api/converter/names.kt
+++ b/api/src/main/kotlin/io/mcarle/konvert/api/converter/names.kt
@@ -1,0 +1,1296 @@
+package io.mcarle.konvert.api.converter
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToByteConverter]
+ */
+const val BOOLEAN_TO_BYTE_CONVERTER = "BooleanToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToCharConverter]
+ */
+const val BOOLEAN_TO_CHAR_CONVERTER = "BooleanToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToDoubleConverter]
+ */
+const val BOOLEAN_TO_DOUBLE_CONVERTER = "BooleanToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToFloatConverter]
+ */
+const val BOOLEAN_TO_FLOAT_CONVERTER = "BooleanToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToIntConverter]
+ */
+const val BOOLEAN_TO_INT_CONVERTER = "BooleanToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToLongConverter]
+ */
+const val BOOLEAN_TO_LONG_CONVERTER = "BooleanToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToNumberConverter]
+ */
+const val BOOLEAN_TO_NUMBER_CONVERTER = "BooleanToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToShortConverter]
+ */
+const val BOOLEAN_TO_SHORT_CONVERTER = "BooleanToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToStringConverter]
+ */
+const val BOOLEAN_TO_STRING_CONVERTER = "BooleanToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToUByteConverter]
+ */
+const val BOOLEAN_TO_UBYTE_CONVERTER = "BooleanToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToUIntConverter]
+ */
+const val BOOLEAN_TO_UINT_CONVERTER = "BooleanToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToULongConverter]
+ */
+const val BOOLEAN_TO_ULONG_CONVERTER = "BooleanToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.BooleanToUShortConverter]
+ */
+const val BOOLEAN_TO_USHORT_CONVERTER = "BooleanToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToBooleanConverter]
+ */
+const val BYTE_TO_BOOLEAN_CONVERTER = "ByteToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToCharConverter]
+ */
+const val BYTE_TO_CHAR_CONVERTER = "ByteToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToDoubleConverter]
+ */
+const val BYTE_TO_DOUBLE_CONVERTER = "ByteToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToEnumConverter]
+ */
+const val BYTE_TO_ENUM_CONVERTER = "ByteToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToFloatConverter]
+ */
+const val BYTE_TO_FLOAT_CONVERTER = "ByteToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToIntConverter]
+ */
+const val BYTE_TO_INT_CONVERTER = "ByteToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToLongConverter]
+ */
+const val BYTE_TO_LONG_CONVERTER = "ByteToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToNumberConverter]
+ */
+const val BYTE_TO_NUMBER_CONVERTER = "ByteToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToShortConverter]
+ */
+const val BYTE_TO_SHORT_CONVERTER = "ByteToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToStringConverter]
+ */
+const val BYTE_TO_STRING_CONVERTER = "ByteToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToUByteConverter]
+ */
+const val BYTE_TO_UBYTE_CONVERTER = "ByteToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToUIntConverter]
+ */
+const val BYTE_TO_UINT_CONVERTER = "ByteToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToULongConverter]
+ */
+const val BYTE_TO_ULONG_CONVERTER = "ByteToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ByteToUShortConverter]
+ */
+const val BYTE_TO_USHORT_CONVERTER = "ByteToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToBooleanConverter]
+ */
+const val CHAR_TO_BOOLEAN_CONVERTER = "CharToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToByteConverter]
+ */
+const val CHAR_TO_BYTE_CONVERTER = "CharToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToDoubleConverter]
+ */
+const val CHAR_TO_DOUBLE_CONVERTER = "CharToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToFloatConverter]
+ */
+const val CHAR_TO_FLOAT_CONVERTER = "CharToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToIntConverter]
+ */
+const val CHAR_TO_INT_CONVERTER = "CharToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToLongConverter]
+ */
+const val CHAR_TO_LONG_CONVERTER = "CharToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToNumberConverter]
+ */
+const val CHAR_TO_NUMBER_CONVERTER = "CharToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToShortConverter]
+ */
+const val CHAR_TO_SHORT_CONVERTER = "CharToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToStringConverter]
+ */
+const val CHAR_TO_STRING_CONVERTER = "CharToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToUByteConverter]
+ */
+const val CHAR_TO_UBYTE_CONVERTER = "CharToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToUIntConverter]
+ */
+const val CHAR_TO_UINT_CONVERTER = "CharToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToULongConverter]
+ */
+const val CHAR_TO_ULONG_CONVERTER = "CharToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.CharToUShortConverter]
+ */
+const val CHAR_TO_USHORT_CONVERTER = "CharToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DateToInstantConverter]
+ */
+const val DATE_TO_INSTANT_CONVERTER = "DateToInstantConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DateToLongEpochMillisConverter]
+ */
+const val DATE_TO_LONG_EPOCH_MILLIS_CONVERTER = "DateToLongEpochMillisConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DateToLongEpochSecondsConverter]
+ */
+const val DATE_TO_LONG_EPOCH_SECONDS_CONVERTER = "DateToLongEpochSecondsConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DateToStringConverter]
+ */
+const val DATE_TO_STRING_CONVERTER = "DateToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToBooleanConverter]
+ */
+const val DOUBLE_TO_BOOLEAN_CONVERTER = "DoubleToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToByteConverter]
+ */
+const val DOUBLE_TO_BYTE_CONVERTER = "DoubleToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToCharConverter]
+ */
+const val DOUBLE_TO_CHAR_CONVERTER = "DoubleToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToEnumConverter]
+ */
+const val DOUBLE_TO_ENUM_CONVERTER = "DoubleToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToFloatConverter]
+ */
+const val DOUBLE_TO_FLOAT_CONVERTER = "DoubleToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToIntConverter]
+ */
+const val DOUBLE_TO_INT_CONVERTER = "DoubleToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToLongConverter]
+ */
+const val DOUBLE_TO_LONG_CONVERTER = "DoubleToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToNumberConverter]
+ */
+const val DOUBLE_TO_NUMBER_CONVERTER = "DoubleToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToShortConverter]
+ */
+const val DOUBLE_TO_SHORT_CONVERTER = "DoubleToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToStringConverter]
+ */
+const val DOUBLE_TO_STRING_CONVERTER = "DoubleToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToUByteConverter]
+ */
+const val DOUBLE_TO_UBYTE_CONVERTER = "DoubleToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToUIntConverter]
+ */
+const val DOUBLE_TO_UINT_CONVERTER = "DoubleToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToULongConverter]
+ */
+const val DOUBLE_TO_ULONG_CONVERTER = "DoubleToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.DoubleToUShortConverter]
+ */
+const val DOUBLE_TO_USHORT_CONVERTER = "DoubleToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToByteConverter]
+ */
+const val ENUM_TO_BYTE_CONVERTER = "EnumToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToCharConverter]
+ */
+const val ENUM_TO_CHAR_CONVERTER = "EnumToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToDoubleConverter]
+ */
+const val ENUM_TO_DOUBLE_CONVERTER = "EnumToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToEnumConverter]
+ */
+const val ENUM_TO_ENUM_CONVERTER = "EnumToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToFloatConverter]
+ */
+const val ENUM_TO_FLOAT_CONVERTER = "EnumToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToIntConverter]
+ */
+const val ENUM_TO_INT_CONVERTER = "EnumToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToLongConverter]
+ */
+const val ENUM_TO_LONG_CONVERTER = "EnumToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToNumberConverter]
+ */
+const val ENUM_TO_NUMBER_CONVERTER = "EnumToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToShortConverter]
+ */
+const val ENUM_TO_SHORT_CONVERTER = "EnumToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToStringConverter]
+ */
+const val ENUM_TO_STRING_CONVERTER = "EnumToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToUByteConverter]
+ */
+const val ENUM_TO_UBYTE_CONVERTER = "EnumToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToUIntConverter]
+ */
+const val ENUM_TO_UINT_CONVERTER = "EnumToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToULongConverter]
+ */
+const val ENUM_TO_ULONG_CONVERTER = "EnumToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.EnumToUShortConverter]
+ */
+const val ENUM_TO_USHORT_CONVERTER = "EnumToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToBooleanConverter]
+ */
+const val FLOAT_TO_BOOLEAN_CONVERTER = "FloatToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToByteConverter]
+ */
+const val FLOAT_TO_BYTE_CONVERTER = "FloatToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToCharConverter]
+ */
+const val FLOAT_TO_CHAR_CONVERTER = "FloatToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToDoubleConverter]
+ */
+const val FLOAT_TO_DOUBLE_CONVERTER = "FloatToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToEnumConverter]
+ */
+const val FLOAT_TO_ENUM_CONVERTER = "FloatToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToIntConverter]
+ */
+const val FLOAT_TO_INT_CONVERTER = "FloatToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToLongConverter]
+ */
+const val FLOAT_TO_LONG_CONVERTER = "FloatToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToNumberConverter]
+ */
+const val FLOAT_TO_NUMBER_CONVERTER = "FloatToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToShortConverter]
+ */
+const val FLOAT_TO_SHORT_CONVERTER = "FloatToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToStringConverter]
+ */
+const val FLOAT_TO_STRING_CONVERTER = "FloatToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToUByteConverter]
+ */
+const val FLOAT_TO_UBYTE_CONVERTER = "FloatToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToUIntConverter]
+ */
+const val FLOAT_TO_UINT_CONVERTER = "FloatToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToULongConverter]
+ */
+const val FLOAT_TO_ULONG_CONVERTER = "FloatToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.FloatToUShortConverter]
+ */
+const val FLOAT_TO_USHORT_CONVERTER = "FloatToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.InstantToDateConverter]
+ */
+const val INSTANT_TO_DATE_CONVERTER = "InstantToDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.InstantToLongEpochMillisConverter]
+ */
+const val INSTANT_TO_LONG_EPOCH_MILLIS_CONVERTER = "InstantToLongEpochMillisConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.InstantToLongEpochSecondsConverter]
+ */
+const val INSTANT_TO_LONG_EPOCH_SECONDS_CONVERTER = "InstantToLongEpochSecondsConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.InstantToStringConverter]
+ */
+const val INSTANT_TO_STRING_CONVERTER = "InstantToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToBooleanConverter]
+ */
+const val INT_TO_BOOLEAN_CONVERTER = "IntToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToByteConverter]
+ */
+const val INT_TO_BYTE_CONVERTER = "IntToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToCharConverter]
+ */
+const val INT_TO_CHAR_CONVERTER = "IntToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToDoubleConverter]
+ */
+const val INT_TO_DOUBLE_CONVERTER = "IntToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToEnumConverter]
+ */
+const val INT_TO_ENUM_CONVERTER = "IntToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToFloatConverter]
+ */
+const val INT_TO_FLOAT_CONVERTER = "IntToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToLongConverter]
+ */
+const val INT_TO_LONG_CONVERTER = "IntToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToNumberConverter]
+ */
+const val INT_TO_NUMBER_CONVERTER = "IntToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToShortConverter]
+ */
+const val INT_TO_SHORT_CONVERTER = "IntToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToStringConverter]
+ */
+const val INT_TO_STRING_CONVERTER = "IntToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToUByteConverter]
+ */
+const val INT_TO_UBYTE_CONVERTER = "IntToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToUIntConverter]
+ */
+const val INT_TO_UINT_CONVERTER = "IntToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToULongConverter]
+ */
+const val INT_TO_ULONG_CONVERTER = "IntToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IntToUShortConverter]
+ */
+const val INT_TO_USHORT_CONVERTER = "IntToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.IterableToIterableConverter]
+ */
+const val ITERABLE_TO_ITERABLE_CONVERTER = "IterableToIterableConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LocalDateTimeToLocalDateConverter]
+ */
+const val LOCAL_DATE_TIME_TO_LOCAL_DATE_CONVERTER = "LocalDateTimeToLocalDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LocalDateTimeToLocalTimeConverter]
+ */
+const val LOCAL_DATE_TIME_TO_LOCAL_TIME_CONVERTER = "LocalDateTimeToLocalTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LocalDateTimeToStringConverter]
+ */
+const val LOCAL_DATE_TIME_TO_STRING_CONVERTER = "LocalDateTimeToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LocalDateToStringConverter]
+ */
+const val LOCAL_DATE_TO_STRING_CONVERTER = "LocalDateToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LocalTimeToStringConverter]
+ */
+const val LOCAL_TIME_TO_STRING_CONVERTER = "LocalTimeToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongEpochMillisToDateConverter]
+ */
+const val LONG_EPOCH_MILLIS_TO_DATE_CONVERTER = "LongEpochMillisToDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongEpochMillisToInstantConverter]
+ */
+const val LONG_EPOCH_MILLIS_TO_INSTANT_CONVERTER = "LongEpochMillisToInstantConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongEpochSecondsToDateConverter]
+ */
+const val LONG_EPOCH_SECONDS_TO_DATE_CONVERTER = "LongEpochSecondsToDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongEpochSecondsToInstantConverter]
+ */
+const val LONG_EPOCH_SECONDS_TO_INSTANT_CONVERTER = "LongEpochSecondsToInstantConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToBooleanConverter]
+ */
+const val LONG_TO_BOOLEAN_CONVERTER = "LongToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToByteConverter]
+ */
+const val LONG_TO_BYTE_CONVERTER = "LongToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToCharConverter]
+ */
+const val LONG_TO_CHAR_CONVERTER = "LongToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToDoubleConverter]
+ */
+const val LONG_TO_DOUBLE_CONVERTER = "LongToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToEnumConverter]
+ */
+const val LONG_TO_ENUM_CONVERTER = "LongToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToFloatConverter]
+ */
+const val LONG_TO_FLOAT_CONVERTER = "LongToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToIntConverter]
+ */
+const val LONG_TO_INT_CONVERTER = "LongToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToNumberConverter]
+ */
+const val LONG_TO_NUMBER_CONVERTER = "LongToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToShortConverter]
+ */
+const val LONG_TO_SHORT_CONVERTER = "LongToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToStringConverter]
+ */
+const val LONG_TO_STRING_CONVERTER = "LongToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToUByteConverter]
+ */
+const val LONG_TO_UBYTE_CONVERTER = "LongToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToUIntConverter]
+ */
+const val LONG_TO_UINT_CONVERTER = "LongToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToULongConverter]
+ */
+const val LONG_TO_ULONG_CONVERTER = "LongToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.LongToUShortConverter]
+ */
+const val LONG_TO_USHORT_CONVERTER = "LongToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.MapToMapConverter]
+ */
+const val MAP_TO_MAP_CONVERTER = "MapToMapConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToBooleanConverter]
+ */
+const val NUMBER_TO_BOOLEAN_CONVERTER = "NumberToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToByteConverter]
+ */
+const val NUMBER_TO_BYTE_CONVERTER = "NumberToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToCharConverter]
+ */
+const val NUMBER_TO_CHAR_CONVERTER = "NumberToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToDoubleConverter]
+ */
+const val NUMBER_TO_DOUBLE_CONVERTER = "NumberToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToEnumConverter]
+ */
+const val NUMBER_TO_ENUM_CONVERTER = "NumberToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToFloatConverter]
+ */
+const val NUMBER_TO_FLOAT_CONVERTER = "NumberToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToIntConverter]
+ */
+const val NUMBER_TO_INT_CONVERTER = "NumberToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToLongConverter]
+ */
+const val NUMBER_TO_LONG_CONVERTER = "NumberToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToShortConverter]
+ */
+const val NUMBER_TO_SHORT_CONVERTER = "NumberToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToStringConverter]
+ */
+const val NUMBER_TO_STRING_CONVERTER = "NumberToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToUByteConverter]
+ */
+const val NUMBER_TO_UBYTE_CONVERTER = "NumberToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToUIntConverter]
+ */
+const val NUMBER_TO_UINT_CONVERTER = "NumberToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToULongConverter]
+ */
+const val NUMBER_TO_ULONG_CONVERTER = "NumberToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.NumberToUShortConverter]
+ */
+const val NUMBER_TO_USHORT_CONVERTER = "NumberToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToDateConverter]
+ */
+const val OFFSET_DATE_TIME_TO_DATE_CONVERTER = "OffsetDateTimeToDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToInstantConverter]
+ */
+const val OFFSET_DATE_TIME_TO_INSTANT_CONVERTER = "OffsetDateTimeToInstantConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToLocalDateConverter]
+ */
+const val OFFSET_DATE_TIME_TO_LOCAL_DATE_CONVERTER = "OffsetDateTimeToLocalDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToLocalDateTimeConverter]
+ */
+const val OFFSET_DATE_TIME_TO_LOCAL_DATE_TIME_CONVERTER = "OffsetDateTimeToLocalDateTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToLocalTimeConverter]
+ */
+const val OFFSET_DATE_TIME_TO_LOCAL_TIME_CONVERTER = "OffsetDateTimeToLocalTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToLongEpochMillisConverter]
+ */
+const val OFFSET_DATE_TIME_TO_LONG_EPOCH_MILLIS_CONVERTER = "OffsetDateTimeToLongEpochMillisConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToLongEpochSecondsConverter]
+ */
+const val OFFSET_DATE_TIME_TO_LONG_EPOCH_SECONDS_CONVERTER = "OffsetDateTimeToLongEpochSecondsConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToOffsetTimeConverter]
+ */
+const val OFFSET_DATE_TIME_TO_OFFSET_TIME_CONVERTER = "OffsetDateTimeToOffsetTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToStringConverter]
+ */
+const val OFFSET_DATE_TIME_TO_STRING_CONVERTER = "OffsetDateTimeToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetDateTimeToZonedDateTimeConverter]
+ */
+const val OFFSET_DATE_TIME_TO_ZONED_DATE_TIME_CONVERTER = "OffsetDateTimeToZonedDateTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetTimeToLocalTimeConverter]
+ */
+const val OFFSET_TIME_TO_LOCAL_TIME_CONVERTER = "OffsetTimeToLocalTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.OffsetTimeToStringConverter]
+ */
+const val OFFSET_TIME_TO_STRING_CONVERTER = "OffsetTimeToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.SameTypeConverter]
+ */
+const val SAME_TYPE_CONVERTER = "SameTypeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToBooleanConverter]
+ */
+const val SHORT_TO_BOOLEAN_CONVERTER = "ShortToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToByteConverter]
+ */
+const val SHORT_TO_BYTE_CONVERTER = "ShortToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToCharConverter]
+ */
+const val SHORT_TO_CHAR_CONVERTER = "ShortToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToDoubleConverter]
+ */
+const val SHORT_TO_DOUBLE_CONVERTER = "ShortToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToEnumConverter]
+ */
+const val SHORT_TO_ENUM_CONVERTER = "ShortToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToFloatConverter]
+ */
+const val SHORT_TO_FLOAT_CONVERTER = "ShortToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToIntConverter]
+ */
+const val SHORT_TO_INT_CONVERTER = "ShortToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToLongConverter]
+ */
+const val SHORT_TO_LONG_CONVERTER = "ShortToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToNumberConverter]
+ */
+const val SHORT_TO_NUMBER_CONVERTER = "ShortToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToStringConverter]
+ */
+const val SHORT_TO_STRING_CONVERTER = "ShortToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToUByteConverter]
+ */
+const val SHORT_TO_UBYTE_CONVERTER = "ShortToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToUIntConverter]
+ */
+const val SHORT_TO_UINT_CONVERTER = "ShortToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToULongConverter]
+ */
+const val SHORT_TO_ULONG_CONVERTER = "ShortToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ShortToUShortConverter]
+ */
+const val SHORT_TO_USHORT_CONVERTER = "ShortToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToBooleanConverter]
+ */
+const val STRING_TO_BOOLEAN_CONVERTER = "StringToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToByteConverter]
+ */
+const val STRING_TO_BYTE_CONVERTER = "StringToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToCharConverter]
+ */
+const val STRING_TO_CHAR_CONVERTER = "StringToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToDateConverter]
+ */
+const val STRING_TO_DATE_CONVERTER = "StringToDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToDoubleConverter]
+ */
+const val STRING_TO_DOUBLE_CONVERTER = "StringToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToEnumConverter]
+ */
+const val STRING_TO_ENUM_CONVERTER = "StringToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToFloatConverter]
+ */
+const val STRING_TO_FLOAT_CONVERTER = "StringToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToInstantConverter]
+ */
+const val STRING_TO_INSTANT_CONVERTER = "StringToInstantConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToIntConverter]
+ */
+const val STRING_TO_INT_CONVERTER = "StringToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToLocalDateConverter]
+ */
+const val STRING_TO_LOCAL_DATE_CONVERTER = "StringToLocalDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToLocalDateTimeConverter]
+ */
+const val STRING_TO_LOCAL_DATE_TIME_CONVERTER = "StringToLocalDateTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToLocalTimeConverter]
+ */
+const val STRING_TO_LOCAL_TIME_CONVERTER = "StringToLocalTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToLongConverter]
+ */
+const val STRING_TO_LONG_CONVERTER = "StringToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToNumberConverter]
+ */
+const val STRING_TO_NUMBER_CONVERTER = "StringToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToOffsetDateTimeConverter]
+ */
+const val STRING_TO_OFFSET_DATE_TIME_CONVERTER = "StringToOffsetDateTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToOffsetTimeConverter]
+ */
+const val STRING_TO_OFFSET_TIME_CONVERTER = "StringToOffsetTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToShortConverter]
+ */
+const val STRING_TO_SHORT_CONVERTER = "StringToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToUByteConverter]
+ */
+const val STRING_TO_UBYTE_CONVERTER = "StringToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToUIntConverter]
+ */
+const val STRING_TO_UINT_CONVERTER = "StringToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToULongConverter]
+ */
+const val STRING_TO_ULONG_CONVERTER = "StringToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToUShortConverter]
+ */
+const val STRING_TO_USHORT_CONVERTER = "StringToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.StringToZonedDateTimeConverter]
+ */
+const val STRING_TO_ZONED_DATE_TIME_CONVERTER = "StringToZonedDateTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ToAnyConverter]
+ */
+const val TO_ANY_CONVERTER = "ToAnyConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToBooleanConverter]
+ */
+const val UBYTE_TO_BOOLEAN_CONVERTER = "UByteToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToByteConverter]
+ */
+const val UBYTE_TO_BYTE_CONVERTER = "UByteToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToCharConverter]
+ */
+const val UBYTE_TO_CHAR_CONVERTER = "UByteToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToDoubleConverter]
+ */
+const val UBYTE_TO_DOUBLE_CONVERTER = "UByteToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToEnumConverter]
+ */
+const val UBYTE_TO_ENUM_CONVERTER = "UByteToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToFloatConverter]
+ */
+const val UBYTE_TO_FLOAT_CONVERTER = "UByteToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToIntConverter]
+ */
+const val UBYTE_TO_INT_CONVERTER = "UByteToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToLongConverter]
+ */
+const val UBYTE_TO_LONG_CONVERTER = "UByteToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToNumberConverter]
+ */
+const val UBYTE_TO_NUMBER_CONVERTER = "UByteToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToShortConverter]
+ */
+const val UBYTE_TO_SHORT_CONVERTER = "UByteToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToStringConverter]
+ */
+const val UBYTE_TO_STRING_CONVERTER = "UByteToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToUIntConverter]
+ */
+const val UBYTE_TO_UINT_CONVERTER = "UByteToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToULongConverter]
+ */
+const val UBYTE_TO_ULONG_CONVERTER = "UByteToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UByteToUShortConverter]
+ */
+const val UBYTE_TO_USHORT_CONVERTER = "UByteToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToBooleanConverter]
+ */
+const val UINT_TO_BOOLEAN_CONVERTER = "UIntToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToByteConverter]
+ */
+const val UINT_TO_BYTE_CONVERTER = "UIntToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToCharConverter]
+ */
+const val UINT_TO_CHAR_CONVERTER = "UIntToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToDoubleConverter]
+ */
+const val UINT_TO_DOUBLE_CONVERTER = "UIntToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToEnumConverter]
+ */
+const val UINT_TO_ENUM_CONVERTER = "UIntToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToFloatConverter]
+ */
+const val UINT_TO_FLOAT_CONVERTER = "UIntToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToIntConverter]
+ */
+const val UINT_TO_INT_CONVERTER = "UIntToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToLongConverter]
+ */
+const val UINT_TO_LONG_CONVERTER = "UIntToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToNumberConverter]
+ */
+const val UINT_TO_NUMBER_CONVERTER = "UIntToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToShortConverter]
+ */
+const val UINT_TO_SHORT_CONVERTER = "UIntToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToStringConverter]
+ */
+const val UINT_TO_STRING_CONVERTER = "UIntToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToUByteConverter]
+ */
+const val UINT_TO_UBYTE_CONVERTER = "UIntToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToULongConverter]
+ */
+const val UINT_TO_ULONG_CONVERTER = "UIntToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UIntToUShortConverter]
+ */
+const val UINT_TO_USHORT_CONVERTER = "UIntToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToBooleanConverter]
+ */
+const val ULONG_TO_BOOLEAN_CONVERTER = "ULongToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToByteConverter]
+ */
+const val ULONG_TO_BYTE_CONVERTER = "ULongToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToCharConverter]
+ */
+const val ULONG_TO_CHAR_CONVERTER = "ULongToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToDoubleConverter]
+ */
+const val ULONG_TO_DOUBLE_CONVERTER = "ULongToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToEnumConverter]
+ */
+const val ULONG_TO_ENUM_CONVERTER = "ULongToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToFloatConverter]
+ */
+const val ULONG_TO_FLOAT_CONVERTER = "ULongToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToIntConverter]
+ */
+const val ULONG_TO_INT_CONVERTER = "ULongToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToLongConverter]
+ */
+const val ULONG_TO_LONG_CONVERTER = "ULongToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToNumberConverter]
+ */
+const val ULONG_TO_NUMBER_CONVERTER = "ULongToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToShortConverter]
+ */
+const val ULONG_TO_SHORT_CONVERTER = "ULongToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToStringConverter]
+ */
+const val ULONG_TO_STRING_CONVERTER = "ULongToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToUByteConverter]
+ */
+const val ULONG_TO_UBYTE_CONVERTER = "ULongToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToUIntConverter]
+ */
+const val ULONG_TO_UINT_CONVERTER = "ULongToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ULongToUShortConverter]
+ */
+const val ULONG_TO_USHORT_CONVERTER = "ULongToUShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToBooleanConverter]
+ */
+const val USHORT_TO_BOOLEAN_CONVERTER = "UShortToBooleanConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToByteConverter]
+ */
+const val USHORT_TO_BYTE_CONVERTER = "UShortToByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToCharConverter]
+ */
+const val USHORT_TO_CHAR_CONVERTER = "UShortToCharConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToDoubleConverter]
+ */
+const val USHORT_TO_DOUBLE_CONVERTER = "UShortToDoubleConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToEnumConverter]
+ */
+const val USHORT_TO_ENUM_CONVERTER = "UShortToEnumConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToFloatConverter]
+ */
+const val USHORT_TO_FLOAT_CONVERTER = "UShortToFloatConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToIntConverter]
+ */
+const val USHORT_TO_INT_CONVERTER = "UShortToIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToLongConverter]
+ */
+const val USHORT_TO_LONG_CONVERTER = "UShortToLongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToNumberConverter]
+ */
+const val USHORT_TO_NUMBER_CONVERTER = "UShortToNumberConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToShortConverter]
+ */
+const val USHORT_TO_SHORT_CONVERTER = "UShortToShortConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToStringConverter]
+ */
+const val USHORT_TO_STRING_CONVERTER = "UShortToStringConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToUByteConverter]
+ */
+const val USHORT_TO_UBYTE_CONVERTER = "UShortToUByteConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToUIntConverter]
+ */
+const val USHORT_TO_UINT_CONVERTER = "UShortToUIntConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.UShortToULongConverter]
+ */
+const val USHORT_TO_ULONG_CONVERTER = "UShortToULongConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToDateConverter]
+ */
+const val ZONED_DATE_TIME_TO_DATE_CONVERTER = "ZonedDateTimeToDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToInstantConverter]
+ */
+const val ZONED_DATE_TIME_TO_INSTANT_CONVERTER = "ZonedDateTimeToInstantConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToLocalDateConverter]
+ */
+const val ZONED_DATE_TIME_TO_LOCAL_DATE_CONVERTER = "ZonedDateTimeToLocalDateConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToLocalDateTimeConverter]
+ */
+const val ZONED_DATE_TIME_TO_LOCAL_DATE_TIME_CONVERTER = "ZonedDateTimeToLocalDateTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToLocalTimeConverter]
+ */
+const val ZONED_DATE_TIME_TO_LOCAL_TIME_CONVERTER = "ZonedDateTimeToLocalTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToLongEpochMillisConverter]
+ */
+const val ZONED_DATE_TIME_TO_LONG_EPOCH_MILLIS_CONVERTER = "ZonedDateTimeToLongEpochMillisConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToLongEpochSecondsConverter]
+ */
+const val ZONED_DATE_TIME_TO_LONG_EPOCH_SECONDS_CONVERTER = "ZonedDateTimeToLongEpochSecondsConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToOffsetDateTimeConverter]
+ */
+const val ZONED_DATE_TIME_TO_OFFSET_DATE_TIME_CONVERTER = "ZonedDateTimeToOffsetDateTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToOffsetTimeConverter]
+ */
+const val ZONED_DATE_TIME_TO_OFFSET_TIME_CONVERTER = "ZonedDateTimeToOffsetTimeConverter"
+
+/**
+ * Name of [io.mcarle.konvert.converter.ZonedDateTimeToStringConverter]
+ */
+const val ZONED_DATE_TIME_TO_STRING_CONVERTER = "ZonedDateTimeToStringConverter"

--- a/converter-api/build.gradle.kts
+++ b/converter-api/build.gradle.kts
@@ -5,5 +5,6 @@ plugins {
 
 
 dependencies {
+    api(project(":api"))
     api(symbolProcessingApi)
 }

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/AbstractTypeConverter.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/AbstractTypeConverter.kt
@@ -2,10 +2,11 @@ package io.mcarle.konvert.converter.api
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSType
-import io.mcarle.konvert.converter.api.config.enforceNotNull
 import io.mcarle.konvert.converter.api.config.Configuration
+import io.mcarle.konvert.converter.api.config.enforceNotNull
 
-abstract class AbstractTypeConverter : TypeConverter {
+abstract class AbstractTypeConverter(name: String? = null) : TypeConverter {
+    override val name: String = name ?: this::class.java.simpleName
     protected lateinit var resolver: Resolver
 
     override fun init(resolver: Resolver) {

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/TypeConverter.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/TypeConverter.kt
@@ -2,6 +2,8 @@ package io.mcarle.konvert.converter.api
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSType
+import io.mcarle.konvert.api.DEFAULT_PRIORITY
+import io.mcarle.konvert.api.Priority
 
 /**
  * All classes, which should be used by Konverter during KSP to identify a conversion from one to another type, have to implement this interface.
@@ -14,6 +16,11 @@ interface TypeConverter {
      * Therefore, [io.mcarle.konvert.converter.StringToIntConverter] is not enabled by default.
      */
     val enabledByDefault: Boolean
+
+    /**
+     * A unique name for the TypeConverter to be able to reference a specific one
+     */
+    val name: String
 
     /**
      * Used to sort all the available converters, as the first matching converter will be used.

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/KonvertOptions.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/KonvertOptions.kt
@@ -1,8 +1,11 @@
 package io.mcarle.konvert.converter.api.config
 
+import io.mcarle.konvert.api.config.ENFORCE_NOT_NULL
+import io.mcarle.konvert.api.config.KONVERTER_GENERATE_CLASS
+
 object KonvertOptions {
-    val ENFORCE_NOT_NULL = Option("konvert.enforce-not-null", false)
-    val KONVERTER_GENERATE_CLASS = Option("konvert.konverter.generate-class", false)
+    val ENFORCE_NOT_NULL_OPTION = Option(ENFORCE_NOT_NULL, false)
+    val KONVERTER_GENERATE_CLASS_OPTION = Option(KONVERTER_GENERATE_CLASS, false)
 }
 
 data class Option<T>(val key: String, val defaultValue: T)

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/extensions.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/extensions.kt
@@ -1,14 +1,16 @@
 package io.mcarle.konvert.converter.api.config
 
 /**
- * Special handling for the case, that the source type is nullable and target type is not nullable:
- * When enabled, the converters will use the not-null assertion operator to enforce the mapped value to be non-null.
- * Otherwise, the converters should not match.
+ * @see io.mcarle.konvert.api.config.ENFORCE_NOT_NULL
  */
 val Configuration.Companion.enforceNotNull: Boolean
-    get() = KonvertOptions.ENFORCE_NOT_NULL.get(CURRENT, String::toBoolean)
+    get() = KonvertOptions.ENFORCE_NOT_NULL_OPTION.get(CURRENT, String::toBoolean)
+
+/**
+ * @see io.mcarle.konvert.api.config.KONVERTER_GENERATE_CLASS
+ */
 val Configuration.Companion.konverterGenerateClass: Boolean
-    get() = KonvertOptions.KONVERTER_GENERATE_CLASS.get(CURRENT, String::toBoolean)
+    get() = KonvertOptions.KONVERTER_GENERATE_CLASS_OPTION.get(CURRENT, String::toBoolean)
 
 /**
  * Reads the value for [Option.key] from the provided `options` or fallbacks to the [Option.defaultValue].

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToXConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToXConverter.kt
@@ -4,8 +4,8 @@ import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
-import io.mcarle.konvert.converter.api.DEFAULT_PRIORITY
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.DEFAULT_PRIORITY
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
 import kotlin.reflect.KClass

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/SameTypeConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/SameTypeConverter.kt
@@ -3,8 +3,8 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.symbol.KSType
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
-import io.mcarle.konvert.converter.api.Priority
-import io.mcarle.konvert.converter.api.SAME_TYPE_PRIORITY
+import io.mcarle.konvert.api.Priority
+import io.mcarle.konvert.api.SAME_TYPE_PRIORITY
 import io.mcarle.konvert.converter.api.TypeConverter
 
 @AutoService(TypeConverter::class)

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToXConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToXConverter.kt
@@ -4,8 +4,8 @@ import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
-import io.mcarle.konvert.converter.api.DEFAULT_PRIORITY
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.DEFAULT_PRIORITY
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
 import java.time.Instant

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/XToDateConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/XToDateConverter.kt
@@ -4,8 +4,8 @@ import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
-import io.mcarle.konvert.converter.api.DEFAULT_PRIORITY
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.DEFAULT_PRIORITY
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
 import kotlin.reflect.KClass

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/XToTemporalConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/XToTemporalConverter.kt
@@ -4,8 +4,8 @@ import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
-import io.mcarle.konvert.converter.api.DEFAULT_PRIORITY
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.DEFAULT_PRIORITY
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
 import java.time.Instant

--- a/converter/src/test/kotlin/io/mcarle/konvert/converter/ExampleTest.kt
+++ b/converter/src/test/kotlin/io/mcarle/konvert/converter/ExampleTest.kt
@@ -23,7 +23,7 @@ class ExampleTest {
 import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Mapping
-import io.mcarle.konvert.converter.StringToIntConverter
+import io.mcarle.konvert.api.converter.STRING_TO_INT_CONVERTER
 
 data class Name(
     val first: String,
@@ -56,7 +56,7 @@ interface FooMapper {
     fun toPersonDto(person: Person): PersonDto
 
     @Konvert(mappings= [
-        Mapping(target = "num", source = "streetNum", enable=[StringToIntConverter::class])
+        Mapping(target = "num", source = "streetNum", enable=[STRING_TO_INT_CONVERTER])
     ])
     fun toAddress(person: Person): Address
 

--- a/example/src/main/kotlin/io/mcarle/konvert/example/Address.kt
+++ b/example/src/main/kotlin/io/mcarle/konvert/example/Address.kt
@@ -2,14 +2,14 @@ package io.mcarle.konvert.example
 
 import io.mcarle.konvert.api.Mapping
 import io.mcarle.konvert.api.KonvertTo
-import io.mcarle.konvert.converter.StringToIntConverter
+import io.mcarle.konvert.api.converter.STRING_TO_INT_CONVERTER
 
 @KonvertTo(
     AddressDto::class,
     mappings = [
         Mapping(source = "street", target = "streetName"),
         Mapping(source = "zip", target = "zipCode"),
-        Mapping(source = "streetNumber", target = "streetNumber", enable = [StringToIntConverter::class]),
+        Mapping(source = "streetNumber", target = "streetNumber", enable = [STRING_TO_INT_CONVERTER]),
     ],
     priority = 1
 )

--- a/example/src/main/kotlin/io/mcarle/konvert/example/Mapper.kt
+++ b/example/src/main/kotlin/io/mcarle/konvert/example/Mapper.kt
@@ -3,8 +3,8 @@ package io.mcarle.konvert.example
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.api.Mapping
-import io.mcarle.konvert.converter.LongToUIntConverter
-import io.mcarle.konvert.converter.StringToIntConverter
+import io.mcarle.konvert.api.converter.LONG_TO_UINT_CONVERTER
+import io.mcarle.konvert.api.converter.STRING_TO_INT_CONVERTER
 import io.mcarle.konvert.injector.spring.KComponent
 
 @Konverter
@@ -22,7 +22,7 @@ interface Mapper {
         mappings = [
             Mapping(source = "street", target = "streetName"),
             Mapping(source = "zip", target = "zipCode"),
-            Mapping(source = "streetNumber", target = "streetNumber", enable = [StringToIntConverter::class])
+            Mapping(source = "streetNumber", target = "streetNumber", enable = [STRING_TO_INT_CONVERTER])
         ]
     )
     fun toDto(address: Address): AddressDto
@@ -32,6 +32,6 @@ interface Mapper {
     )
     fun fromDto(dto: PersonDto): Person
 
-    @Konvert(mappings = [Mapping(source = "age", target = "numberOfYearsSinceBirth", enable = [LongToUIntConverter::class])])
+    @Konvert(mappings = [Mapping(source = "age", target = "numberOfYearsSinceBirth", enable = [LONG_TO_UINT_CONVERTER])])
     fun toDto(person: Person): PersonDto
 }

--- a/example/src/main/kotlin/io/mcarle/konvert/example/Person.kt
+++ b/example/src/main/kotlin/io/mcarle/konvert/example/Person.kt
@@ -2,13 +2,14 @@ package io.mcarle.konvert.example
 
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
+import io.mcarle.konvert.api.converter.LONG_TO_UINT_CONVERTER
 import io.mcarle.konvert.converter.IntToUIntConverter
 import io.mcarle.konvert.converter.LongToUIntConverter
 
 @KonvertTo(
     value = PersonDto::class,
     mappings = [
-        Mapping(source = "age", target = "numberOfYearsSinceBirth", enable = [LongToUIntConverter::class]),
+        Mapping(source = "age", target = "numberOfYearsSinceBirth", enable = [LONG_TO_UINT_CONVERTER]),
     ]
 )
 @KonvertTo(value = PersonDao::class)

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/PropertyMappingInfo.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/PropertyMappingInfo.kt
@@ -1,8 +1,7 @@
 package io.mcarle.konvert.processor.codegen
 
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
-import io.mcarle.konvert.converter.api.TypeConverter
-import kotlin.reflect.KClass
+import io.mcarle.konvert.api.TypeConverterName
 
 data class PropertyMappingInfo constructor(
     val mappingParamName: String?,
@@ -12,7 +11,7 @@ data class PropertyMappingInfo constructor(
     val expression: String?,
     val ignore: Boolean,
     val nullable: Boolean,
-    val enableConverters: List<KClass<out TypeConverter>>,
+    val enableConverters: List<TypeConverterName>,
     val declaration: KSPropertyDeclaration?,
     val isBasedOnAnnotation: Boolean
 )

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/extensions.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/extensions.kt
@@ -10,6 +10,7 @@ import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.Mapping
 import io.mcarle.konvert.api.NoParamDefinedException
 import io.mcarle.konvert.api.NotAllowedParameterCombinationException
+import io.mcarle.konvert.api.TypeConverterName
 import io.mcarle.konvert.api.validate
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.classDeclaration
@@ -43,11 +44,7 @@ fun Mapping.Companion.from(annotation: KSAnnotation) = Mapping(
     expression = annotation.arguments.first { it.name?.asString() == Mapping::expression.name }.value as String,
     ignore = annotation.arguments.first { it.name?.asString() == Mapping::ignore.name }.value as Boolean,
     enable = (annotation.arguments.first { it.name?.asString() == Mapping::enable.name }.value as List<*>)
-        .filterIsInstance<KSType>()
-        .map {
-            Class.forName(it.declaration.qualifiedName!!.asString(), true, TypeConverter::class.java.classLoader).kotlin
-        }
-        .filterIsInstance<KClass<out TypeConverter>>()
+        .filterIsInstance<TypeConverterName>()
         .toTypedArray(),
 )
 

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
@@ -10,7 +10,7 @@ import com.google.devtools.ksp.symbol.KSTypeReference
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.Mapping
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.classDeclaration
 import io.mcarle.konvert.processor.from
 

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertTypeConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertTypeConverter.kt
@@ -4,7 +4,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.isNullable
 
 class KonvertTypeConverter constructor(

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterData.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.Konverter
-import io.mcarle.konvert.converter.api.DEFAULT_KONVERTER_PRIORITY
+import io.mcarle.konvert.api.DEFAULT_KONVERTER_PRIORITY
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.processor.AnnotatedConverterData
 import io.mcarle.konvert.processor.from

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromData.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.Mapping
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.classDeclaration
 import io.mcarle.konvert.processor.AnnotatedConverterData

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromTypeConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromTypeConverter.kt
@@ -3,7 +3,7 @@ package io.mcarle.konvert.processor.konvertfrom
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.isNullable
 
 class KonvertFromTypeConverter constructor(

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToData.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.ksp.toClassName
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.classDeclaration
 import io.mcarle.konvert.processor.AnnotatedConverterData

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToTypeConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToTypeConverter.kt
@@ -3,7 +3,7 @@ package io.mcarle.konvert.processor.konvertto
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
-import io.mcarle.konvert.converter.api.Priority
+import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.isNullable
 
 class KonvertToTypeConverter constructor(

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/TargetStructureITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/TargetStructureITest.kt
@@ -195,10 +195,10 @@ class TargetClass(
                 """
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
-import io.mcarle.konvert.converter.StringToIntConverter
+import io.mcarle.konvert.api.converter.STRING_TO_INT_CONVERTER
 
 @KonvertTo(TargetClass::class, mappings=[
-    Mapping(source="sourceProperty", target="targetProperty", enable=[StringToIntConverter::class])
+    Mapping(source="sourceProperty", target="targetProperty", enable=[STRING_TO_INT_CONVERTER])
 ])
 class SourceClass(
     val sourceProperty: String

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
@@ -6,8 +6,8 @@ import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.converter.SameTypeConverter
 import io.mcarle.konvert.api.DEFAULT_KONVERTER_PRIORITY
 import io.mcarle.konvert.api.DEFAULT_KONVERT_PRIORITY
+import io.mcarle.konvert.api.config.KONVERTER_GENERATE_CLASS
 import io.mcarle.konvert.converter.api.TypeConverterRegistry
-import io.mcarle.konvert.converter.api.config.KonvertOptions
 import io.mcarle.konvert.processor.KonverterITest
 import io.mcarle.konvert.processor.generatedSourceFor
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
@@ -354,7 +354,7 @@ interface OtherMapper {
             enabledConverters = listOf(SameTypeConverter()),
             otherConverters = emptyList(),
             expectSuccess = true,
-            options = mapOf(KonvertOptions.KONVERTER_GENERATE_CLASS.key to "false"),
+            options = mapOf(KONVERTER_GENERATE_CLASS to "false"),
             SourceFile.kotlin(
                 name = "SourceClass.kt",
                 contents =
@@ -379,7 +379,7 @@ import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konfig
 
-@Konverter(options=[Konfig(key = "${KonvertOptions.KONVERTER_GENERATE_CLASS.key}", value = "true")])
+@Konverter(options=[Konfig(key = "$KONVERTER_GENERATE_CLASS", value = "true")])
 interface SomeConverter {
     @Konvert
     fun toTargetClass(source: SourceClass): TargetClass

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
@@ -4,8 +4,8 @@ import com.squareup.kotlinpoet.ksp.toClassName
 import com.tschuchort.compiletesting.SourceFile
 import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.converter.SameTypeConverter
-import io.mcarle.konvert.converter.api.DEFAULT_KONVERTER_PRIORITY
-import io.mcarle.konvert.converter.api.DEFAULT_KONVERT_PRIORITY
+import io.mcarle.konvert.api.DEFAULT_KONVERTER_PRIORITY
+import io.mcarle.konvert.api.DEFAULT_KONVERT_PRIORITY
 import io.mcarle.konvert.converter.api.TypeConverterRegistry
 import io.mcarle.konvert.converter.api.config.KonvertOptions
 import io.mcarle.konvert.processor.KonverterITest

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromITest.kt
@@ -2,7 +2,7 @@ package io.mcarle.konvert.processor.konvertfrom
 
 import com.tschuchort.compiletesting.SourceFile
 import io.mcarle.konvert.converter.SameTypeConverter
-import io.mcarle.konvert.converter.api.DEFAULT_KONVERT_FROM_PRIORITY
+import io.mcarle.konvert.api.DEFAULT_KONVERT_FROM_PRIORITY
 import io.mcarle.konvert.converter.api.TypeConverterRegistry
 import io.mcarle.konvert.processor.KonverterITest
 import io.mcarle.konvert.processor.generatedSourceFor

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
@@ -2,7 +2,7 @@ package io.mcarle.konvert.processor.konvertto
 
 import com.tschuchort.compiletesting.SourceFile
 import io.mcarle.konvert.converter.SameTypeConverter
-import io.mcarle.konvert.converter.api.DEFAULT_KONVERT_TO_PRIORITY
+import io.mcarle.konvert.api.DEFAULT_KONVERT_TO_PRIORITY
 import io.mcarle.konvert.converter.api.TypeConverterRegistry
 import io.mcarle.konvert.processor.KonverterITest
 import io.mcarle.konvert.processor.generatedSourceFor


### PR DESCRIPTION
Removes the need to have the actual `TypeConverter` in your source code available in case you want to enable one for a mapping. Instead, all `TypeConverter`s now have a name and you can define the name instead.

For a help, all available `TypeConverter` names are now defined as constants in `api` module.
Also added available option names to `api` module.