### PR TITLE
Add options for default injection for koin injector

### DIFF
--- a/injectors/koin-annotations/src/main/kotlin/io/mcarle/konvert/injector/koin/config/names.kt
+++ b/injectors/koin-annotations/src/main/kotlin/io/mcarle/konvert/injector/koin/config/names.kt
@@ -1,0 +1,20 @@
+package io.mcarle.konvert.injector.koin.config
+
+/**
+ * Append some injection method by default to all generated mapper classes.
+ *
+ * Possible values: `factory`, `single`, `scope` (requires `konvert.koin.default-scope` to be set as well!)
+ *
+ * Default: disabled
+ */
+const val DEFAULT_INJECTION_METHOD = "konvert.koin.default-injection-method"
+
+/**
+ * Use this scope by default when `konvert.koin.default-injection-method` is set to `scope`.
+ *
+ * - If value is fully qualified class identifier it will by used as `@Scope(ProvidedType::class)`.
+ * - If value is string - it will be used as named scope, like `@Scope(name = "ProvidedName")`
+ *
+ * Default: ""
+ */
+const val DEFAULT_SCOPE = "konvert.koin.default-scope"

--- a/injectors/koin-injector/src/main/kotlin/io/mcarle/konvert/injector/koin/KoinInjector.kt
+++ b/injectors/koin-injector/src/main/kotlin/io/mcarle/konvert/injector/koin/KoinInjector.kt
@@ -13,12 +13,49 @@ import com.squareup.kotlinpoet.ksp.toAnnotationSpec
 import io.mcarle.konvert.plugin.api.KonverterInjector
 import io.mcarle.konvert.plugin.api.extendProxy
 import com.squareup.kotlinpoet.ksp.toTypeName
+import io.mcarle.konvert.converter.api.config.Configuration
+import io.mcarle.konvert.injector.koin.config.DEFAULT_INJECTION_METHOD
+import io.mcarle.konvert.injector.koin.config.InjectionMethod
+import io.mcarle.konvert.injector.koin.config.defaultInjectionMethod
+import io.mcarle.konvert.injector.koin.config.defaultScope
 import org.koin.core.annotation.*
 
 @AutoService(KonverterInjector::class)
 class KoinInjector : KonverterInjector {
 
     override fun processType(builder: TypeSpec.Builder, originKSClassDeclaration: KSClassDeclaration) {
+        applyDefaults(builder)
+        processAnnotations(builder, originKSClassDeclaration)
+    }
+
+    private fun applyDefaults(builder: TypeSpec.Builder) {
+        when (Configuration.defaultInjectionMethod) {
+            InjectionMethod.DISABLED -> return
+            InjectionMethod.FACTORY -> builder.addAnnotation(Factory::class)
+            InjectionMethod.SINGLE -> builder.addAnnotation(Single::class)
+            InjectionMethod.SCOPE -> {
+                val scopeString = Configuration.defaultScope
+                require(scopeString.isNotBlank()) {
+                    "The scope setting cannot be empty"
+                }
+                val annotationBuilder = AnnotationSpec.builder(Scope::class)
+                val nameSegments = scopeString.split(".")
+                if (nameSegments.count() == 1) {
+                    annotationBuilder.addMember("name = %S", scopeString)
+                } else {
+                    val className = ClassName(nameSegments.dropLast(1).joinToString("."), nameSegments.last())
+                    // at this point we are pretty sure that user passed qualified name
+                    annotationBuilder.addMember("value = %T::class", className)
+                }
+                builder.addAnnotation(annotationBuilder.build())
+            }
+        }
+    }
+
+    private fun processAnnotations(
+        builder: TypeSpec.Builder,
+        originKSClassDeclaration: KSClassDeclaration
+    ) {
         passthroughAnnotation<KSingle, Single>(builder, originKSClassDeclaration) {
             it.value
         }

--- a/injectors/koin-injector/src/main/kotlin/io/mcarle/konvert/injector/koin/config/KoinOptions.kt
+++ b/injectors/koin-injector/src/main/kotlin/io/mcarle/konvert/injector/koin/config/KoinOptions.kt
@@ -1,0 +1,15 @@
+package io.mcarle.konvert.injector.koin.config
+
+import io.mcarle.konvert.converter.api.config.Option
+
+object KoinOptions {
+    val DEFAULT_INJECTION_METHOD_OPTION = Option(DEFAULT_INJECTION_METHOD, InjectionMethod.DISABLED)
+    val DEFAULT_SCOPE_OPTION = Option(DEFAULT_SCOPE, "")
+}
+
+enum class InjectionMethod {
+    DISABLED,
+    FACTORY,
+    SINGLE,
+    SCOPE
+}

--- a/injectors/koin-injector/src/main/kotlin/io/mcarle/konvert/injector/koin/config/extensions.kt
+++ b/injectors/koin-injector/src/main/kotlin/io/mcarle/konvert/injector/koin/config/extensions.kt
@@ -1,0 +1,12 @@
+package io.mcarle.konvert.injector.koin.config
+
+import io.mcarle.konvert.converter.api.config.Configuration
+import io.mcarle.konvert.converter.api.config.get
+
+val Configuration.Companion.defaultInjectionMethod: InjectionMethod
+    get() = KoinOptions.DEFAULT_INJECTION_METHOD_OPTION.get(CURRENT) {
+        InjectionMethod.valueOf(it.uppercase())
+    }
+
+val Configuration.Companion.defaultScope: String
+    get() = KoinOptions.DEFAULT_SCOPE_OPTION.get(CURRENT) { it }

--- a/injectors/koin-injector/src/test/kotlin/io/mcarle/konvert/injector/koin/KoinInjectorITest.kt
+++ b/injectors/koin-injector/src/test/kotlin/io/mcarle/konvert/injector/koin/KoinInjectorITest.kt
@@ -2,6 +2,8 @@ package io.mcarle.konvert.injector.koin
 
 import com.tschuchort.compiletesting.SourceFile
 import io.mcarle.konvert.converter.SameTypeConverter
+import io.mcarle.konvert.injector.koin.config.DEFAULT_INJECTION_METHOD
+import io.mcarle.konvert.injector.koin.config.DEFAULT_SCOPE
 import io.mcarle.konvert.processor.KonverterITest
 import io.mcarle.konvert.processor.generatedSourceFor
 import org.junit.jupiter.api.Test
@@ -296,5 +298,155 @@ class TargetClass(val property: String)
         assertContains(mapperCode, "@Scope(name = \"scope_name\")")
         assertContains(mapperCode, "org.koin.core.`annotation`.Scoped")
         assertContains(mapperCode, "@Scoped")
+    }
+
+    @Test
+    fun defaultFactory() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            otherConverters = emptyList(),
+            expectSuccess = true,
+            options = mapOf(DEFAULT_INJECTION_METHOD to "factory"),
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.injector.koin.KFactory
+import io.mcarle.konvert.injector.koin.KScope
+import io.mcarle.konvert.injector.koin.KScoped
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun toTarget(source: SourceClass): TargetClass
+}
+
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertContains(mapperCode, "org.koin.core.`annotation`.Factory")
+        assertContains(mapperCode, "@Factory")
+    }
+
+    @Test
+    fun defaultSingle() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            otherConverters = emptyList(),
+            expectSuccess = true,
+            options = mapOf(DEFAULT_INJECTION_METHOD to "single"),
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.injector.koin.KFactory
+import io.mcarle.konvert.injector.koin.KScope
+import io.mcarle.konvert.injector.koin.KScoped
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun toTarget(source: SourceClass): TargetClass
+}
+
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertContains(mapperCode, "org.koin.core.`annotation`.Single")
+        assertContains(mapperCode, "@Single")
+    }
+
+    @Test
+    fun defaultScopeWithClassParam() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            otherConverters = emptyList(),
+            expectSuccess = true,
+            options = mapOf(DEFAULT_INJECTION_METHOD to "scope", DEFAULT_SCOPE to "test.module.TestScope"),
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+package test.module
+
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.injector.koin.KFactory
+import io.mcarle.konvert.injector.koin.KScope
+import io.mcarle.konvert.injector.koin.KScoped
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun toTarget(source: SourceClass): TargetClass
+}
+
+object TestScope
+
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertContains(mapperCode, "org.koin.core.`annotation`.Scope")
+        assertContains(mapperCode, "@Scope")
+        assertContains(mapperCode, "value = TestScope::class")
+    }
+
+    @Test
+    fun defaultScopeWithStringParam() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            otherConverters = emptyList(),
+            expectSuccess = true,
+            options = mapOf(DEFAULT_INJECTION_METHOD to "scope", DEFAULT_SCOPE to "ScopeName"),
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+package test.module
+
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.injector.koin.KFactory
+import io.mcarle.konvert.injector.koin.KScope
+import io.mcarle.konvert.injector.koin.KScoped
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun toTarget(source: SourceClass): TargetClass
+}
+
+object TestScope
+
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertContains(mapperCode, "org.koin.core.`annotation`.Scope")
+        assertContains(mapperCode, "@Scope")
+        assertContains(mapperCode, "name = \"ScopeName\"")
     }
 }


### PR DESCRIPTION
From my experience pretty much all mappers we are using are annotated with `@Factory`. This PR adds the option for applying default annotations that apply (so it allows for `@Factory`, `@Single` and `@Scope` - even though i don't think there is much gain from shared scope for all of the mappers)