### PR TITLE
Change return type in TypeConverter from String to CodeBlock

### DIFF
--- a/converter-api/build.gradle.kts
+++ b/converter-api/build.gradle.kts
@@ -7,4 +7,5 @@ plugins {
 dependencies {
     api(project(":annotations"))
     api(symbolProcessingApi)
+    api(kotlinPoet)
 }

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/TypeConverter.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/TypeConverter.kt
@@ -2,6 +2,7 @@ package io.mcarle.konvert.converter.api
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.DEFAULT_PRIORITY
 import io.mcarle.konvert.api.Priority
 
@@ -43,5 +44,5 @@ interface TypeConverter {
      *
      * @param fieldName the property name, which should be converted
      */
-    fun convert(fieldName: String, source: KSType, target: KSType): String
+    fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock
 }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/BaseTypeConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/BaseTypeConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
@@ -29,15 +30,17 @@ abstract class BaseTypeConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "")
 
-        return if (needsNotNullAssertionOperator(source, target)) {
-            appendNotNullAssertionOperator(convertCode)
-        } else {
-            convertCode
-        }
+        return CodeBlock.of(
+            if (needsNotNullAssertionOperator(source, target)) {
+                appendNotNullAssertionOperator(convertCode)
+            } else {
+                convertCode
+            }
+        )
     }
 
     abstract fun convert(fieldName: String, nc: String): String

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToTemporalConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToTemporalConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
@@ -28,11 +29,13 @@ abstract class DateToTemporalConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "")
 
-        return convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     abstract fun convert(fieldName: String, nc: String): String

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToXConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToXConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.DEFAULT_PRIORITY
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
@@ -28,11 +29,13 @@ abstract class DateToXConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "")
 
-        return convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     abstract fun convert(fieldName: String, nc: String): String

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/EnumToEnumConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/EnumToEnumConverter.kt
@@ -5,6 +5,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.classDeclaration
@@ -25,7 +26,7 @@ class EnumToEnumConverter : AbstractTypeConverter() {
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceEnumValues = source.classDeclaration()?.declarations
             ?.filter { it is KSClassDeclaration && it.classKind == ClassKind.ENUM_ENTRY }
             ?.toList() ?: emptyList()
@@ -43,7 +44,7 @@ class EnumToEnumConverter : AbstractTypeConverter() {
 
 
         // @formatter:off
-        return """
+        return CodeBlock.of("""
 when·($fieldName)·{${ "\n⇥" +
         sourceEnumValues.joinToString("\n") {
             "${source.declaration.qualifiedName?.asString()}.${it.simpleName.asString()}·->·${target.declaration.qualifiedName?.asString()}.${it.simpleName.asString()}"
@@ -56,7 +57,8 @@ when·($fieldName)·{${ "\n⇥" +
         }
 }
 ⇤}${if (needsNotNullAssertionOperator(source, target)) "!!" else ""}
-        """.trimIndent()
+            """.trimIndent()
+        )
         // @formatter:on
     }
 

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/EnumToXConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/EnumToXConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
@@ -28,11 +29,13 @@ abstract class EnumToXConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "")
 
-        return convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     abstract fun convert(fieldName: String, nc: String): String

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/IterableToIterableConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/IterableToIterableConverter.kt
@@ -4,6 +4,7 @@ import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Variance
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.TypeConverterRegistry
@@ -56,7 +57,7 @@ class IterableToIterableConverter : AbstractTypeConverter() {
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val genericTargetVariance = target.arguments[0].variance.let {
             if (it == Variance.INVARIANT) {
                 target.declaration.typeParameters[0].variance
@@ -115,11 +116,13 @@ class IterableToIterableConverter : AbstractTypeConverter() {
 
         val code = mapSourceContentCode + mapSourceContainerCode + appendNotNullAssertionOperatorIfNeeded(source, target)
 
-        return if (castNeeded) {
-            "($code·as·$target)" // encapsulate with braces
-        } else {
-            code
-        }
+        return CodeBlock.of(
+            if (castNeeded) {
+                "($code·as·$target)" // encapsulate with braces
+            } else {
+                code
+            }
+        )
     }
 
     private fun KSType.isExactly(qualifiedName: String): Boolean {

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/MapToMapConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/MapToMapConverter.kt
@@ -4,6 +4,7 @@ import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.Variance
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.TypeConverterRegistry
@@ -52,7 +53,7 @@ class MapToMapConverter : AbstractTypeConverter() {
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val genericTargetKeyVariance = target.arguments[0].variance.let {
             if (it == Variance.INVARIANT) {
                 target.declaration.typeParameters[0].variance
@@ -240,11 +241,13 @@ newKey·to·newValue
 
         val code = mapSourceContentCode + mapSourceContainerCode + appendNotNullAssertionOperatorIfNeeded(source, target)
 
-        return if (castNeeded) {
-            "($code·as·$target)" // encapsulate with braces
-        } else {
-            code
-        }
+        return CodeBlock.of(
+            if (castNeeded) {
+                "($code·as·$target)" // encapsulate with braces
+            } else {
+                code
+            }
+        )
     }
 
 

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/SameTypeConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/SameTypeConverter.kt
@@ -2,6 +2,7 @@ package io.mcarle.konvert.converter
 
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.api.SAME_TYPE_PRIORITY
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
@@ -18,7 +19,9 @@ class SameTypeConverter : AbstractTypeConverter() {
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
-        return fieldName + appendNotNullAssertionOperatorIfNeeded(source, target)
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
+        return CodeBlock.of(
+            fieldName + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToDateConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToDateConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
@@ -30,11 +31,13 @@ abstract class TemporalToDateConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "")
 
-        return convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     override val enabledByDefault: Boolean = true

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToTemporalConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToTemporalConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
@@ -35,11 +36,13 @@ abstract class TemporalToTemporalConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "")
 
-        return convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     override val enabledByDefault: Boolean = true

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToXConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToXConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.DEFAULT_PRIORITY
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
@@ -37,11 +38,13 @@ abstract class TemporalToXConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "")
 
-        return convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     override val enabledByDefault: Boolean = true

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/ToAnyConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/ToAnyConverter.kt
@@ -2,6 +2,7 @@ package io.mcarle.konvert.converter
 
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 
@@ -16,8 +17,10 @@ class ToAnyConverter : AbstractTypeConverter() {
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
-        return fieldName + appendNotNullAssertionOperatorIfNeeded(source, target)
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
+        return CodeBlock.of(
+            fieldName + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     override val enabledByDefault: Boolean = true

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/XToDateConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/XToDateConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.DEFAULT_PRIORITY
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
@@ -28,11 +29,13 @@ abstract class XToDateConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "")
 
-        return convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     override val enabledByDefault: Boolean = false

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/XToEnumConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/XToEnumConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.isNullable
@@ -29,11 +30,13 @@ abstract class XToEnumConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "", target.declaration.qualifiedName!!.asString())
 
-        return convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     override val enabledByDefault: Boolean = false

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/XToTemporalConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/XToTemporalConverter.kt
@@ -3,6 +3,7 @@ package io.mcarle.konvert.converter
 import com.google.auto.service.AutoService
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.DEFAULT_PRIORITY
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
@@ -37,11 +38,13 @@ abstract class XToTemporalConverter(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val sourceNullable = source.isNullable()
         val convertCode = convert(fieldName, if (sourceNullable) "?" else "")
 
-        return convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            convertCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
     override val enabledByDefault: Boolean = false

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/CodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/CodeGenerator.kt
@@ -10,6 +10,7 @@ import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueParameter
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.Mapping
 import io.mcarle.konvert.converter.api.classDeclaration
 import io.mcarle.konvert.converter.api.config.Configuration
@@ -30,7 +31,7 @@ class CodeGenerator(
         source: KSType,
         target: KSType,
         mappingCodeParentDeclaration: KSDeclaration
-    ): String {
+    ): CodeBlock {
         val sourceProperties = PropertyMappingResolver(logger).determinePropertyMappings(paramName, mappings, source)
 
         val targetClassDeclaration = target.classDeclaration()!!

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertTypeConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertTypeConverter.kt
@@ -2,6 +2,7 @@ package io.mcarle.konvert.processor.konvert
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
@@ -54,7 +55,7 @@ class KonvertTypeConverter constructor(
         return false
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val getKonverterCode = if (CurrentInterfaceContext.interfaceKSClassDeclaration == mapKSClassDeclaration) {
             "this"
         } else {
@@ -65,7 +66,7 @@ class KonvertTypeConverter constructor(
         } else {
             "$getKonverterCode.$mapFunctionName($paramName·=·$fieldName)"
         }
-        return mappingCode + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(mappingCode + appendNotNullAssertionOperatorIfNeeded(source, target))
     }
 
 }

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromTypeConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromTypeConverter.kt
@@ -2,6 +2,7 @@ package io.mcarle.konvert.processor.konvertfrom
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.isNullable
@@ -25,11 +26,13 @@ class KonvertFromTypeConverter constructor(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
-        return if (source.isNullable()) {
-            "$fieldName?.let·{ ${targetClassDeclaration.qualifiedName?.asString()}.$mapFunctionName($paramName·=·it) }"
-        } else {
-            "${targetClassDeclaration.qualifiedName?.asString()}.$mapFunctionName($paramName·=·$fieldName)"
-        } + appendNotNullAssertionOperatorIfNeeded(source, target)
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
+        return CodeBlock.of(
+            if (source.isNullable()) {
+                "$fieldName?.let·{ ${targetClassDeclaration.qualifiedName?.asString()}.$mapFunctionName($paramName·=·it) }"
+            } else {
+                "${targetClassDeclaration.qualifiedName?.asString()}.$mapFunctionName($paramName·=·$fieldName)"
+            } + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 }

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToTypeConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToTypeConverter.kt
@@ -2,6 +2,7 @@ package io.mcarle.konvert.processor.konvertto
 
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.CodeBlock
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.isNullable
@@ -24,9 +25,11 @@ class KonvertToTypeConverter constructor(
         }
     }
 
-    override fun convert(fieldName: String, source: KSType, target: KSType): String {
+    override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val nc = if (source.isNullable()) "?" else ""
-        return "$fieldName$nc.$mapFunctionName()" + appendNotNullAssertionOperatorIfNeeded(source, target)
+        return CodeBlock.of(
+            "$fieldName$nc.$mapFunctionName()" + appendNotNullAssertionOperatorIfNeeded(source, target)
+        )
     }
 
 }

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
@@ -147,7 +147,11 @@ class TargetProperty<E>(val value: E)
         val extensionFunctionCode = compilation.generatedSourceFor("SourceClassKonverter.kt")
         println(extensionFunctionCode)
 
-        assertContains(extensionFunctionCode, "get<KonvertInterface>().toTargetProperty(sourceProperty = ")
+        assertSourceEquals("""
+            public fun SourceClass.toTargetClass(): TargetClass = TargetClass(
+              targetProperty = io.mcarle.konvert.api.Konverter.get<KonvertInterface>().toTargetProperty(sourceProperty = sourceProperty)
+            )
+        """.trimIndent(), extensionFunctionCode)
     }
 
     @Test

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
@@ -148,8 +148,10 @@ class TargetProperty<E>(val value: E)
         println(extensionFunctionCode)
 
         assertSourceEquals("""
+            import io.mcarle.konvert.api.Konverter
+
             public fun SourceClass.toTargetClass(): TargetClass = TargetClass(
-              targetProperty = io.mcarle.konvert.api.Konverter.get<KonvertInterface>().toTargetProperty(sourceProperty = sourceProperty)
+              targetProperty = Konverter.get<KonvertInterface>().toTargetProperty(sourceProperty = sourceProperty)
             )
         """.trimIndent(), extensionFunctionCode)
     }


### PR DESCRIPTION
To be able to use more functionality from kotlinpoet in `TypeConverter`s `convert` fun, a `CodeBlock` instead of a simple `String` has to be returned.

This PR/MR does exactly this, while also improving the `KonvertTypeConverter`, which now uses kotlinpoet's `%T` type placeholder with arguments in a `CodeBlock`.