### PR TITLE
feat: register generated konverter functions of other modules or libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To use `Konvert` with Gradle, you have to do the following steps:
 2. Add the KSP plugin matching your Kotlin version:
    ```kotlin
    plugins {
-       id("com.google.devtools.ksp").version("1.8.10-1.0.9")
+       id("com.google.devtools.ksp").version("1.8.21-1.0.11")
    }
    ```
 
@@ -110,14 +110,13 @@ There are three different ways to use `Konvert`:
       Person(firstName = personDto.firstName, lastName = personDto.lastName)
    ```
 
-3. Using `@Konverter` and `@Konvert`:
+3. Using `@Konverter`:
    ```kotlin
    data class Person(val firstName: String, val lastName: String)
    data class PersonDto(val firstName: String, val lastName: String)
 
    @Konverter
    interface PersonMapper {
-      @Konvert
       fun toDto(person: Person): PersonDto
    }
    ```
@@ -182,14 +181,14 @@ fun Person.asDto(): PersonDto = PersonDto(
 ```
 
 For further functionality, have a look into
-the [documentation](https://mcarleio.github.io/konvert/typeconverter/provided.html)
+the [documentation](https://mcarleio.github.io/konvert/)
 the KDocs of the [annotations](annotations/src/main/kotlin/io/mcarle/konvert/api),
 the [example project](example/src/main/kotlin/io/mcarle/konvert/example)
 or the [tests](processor/src/test/kotlin/io/mcarle/konvert/processor).
 
 ## Further information
 
-* `Konvert` is primarily compiled and tested with JDK >=17. It should, but is not guaranteed to work with anything below JDK 17.
+* `Konvert` is primarily compiled and tested with JDK >=17. It should also work with anything below JDK 17, but is not guaranteed to.
 * `Konvert` is able to convert classes from and to classes written in Java (and probably also in other JVM languages).
 
 ## Building

--- a/annotations/src/main/kotlin/io/mcarle/konvert/api/GeneratedKonverter.kt
+++ b/annotations/src/main/kotlin/io/mcarle/konvert/api/GeneratedKonverter.kt
@@ -1,0 +1,7 @@
+package io.mcarle.konvert.api
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class GeneratedKonverter(
+    val priority: Priority
+)

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/KonvertOptions.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/KonvertOptions.kt
@@ -48,3 +48,22 @@ object KONVERTER_GENERATE_CLASS_OPTION : Option<Boolean>("konvert.konverter.gene
  * Default: `Konverter`
  */
 object GENERATED_FILENAME_SUFFIX_OPTION : Option<String>("konvert.generated-filename-suffix", "Konverter")
+
+/**
+ * This setting will, if enabled, add @[io.mcarle.konvert.api.GeneratedKonverter] to all generated functions
+ *
+ * Given:
+ * ```kotlin
+ * @KonvertTo(SomeTargetClass::class)
+ * class SomeSourceClass
+ * ```
+ *
+ * When enabled, will add the annotation like this:
+ * ```kotlin
+ * @GeneratedKonverter(priority = 3000)
+ * fun SomeSourceClass.toSomeTargetClass() = SomeTargetClass()
+ * ```
+ *
+ * Default: true
+ */
+object ADD_GENERATED_KONVERTER_ANNOTATION_OPTION : Option<Boolean>("konvert.add-generated-konverter-annotation", true)

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/extensions.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/extensions.kt
@@ -19,6 +19,12 @@ val Configuration.Companion.generatedFilenameSuffix: String
     get() = GENERATED_FILENAME_SUFFIX_OPTION.get(CURRENT) { it }
 
 /**
+ * @see ADD_GENERATED_KONVERTER_ANNOTATION_OPTION
+ */
+val Configuration.Companion.addGeneratedKonverterAnnotation: Boolean
+    get() = ADD_GENERATED_KONVERTER_ANNOTATION_OPTION.get(CURRENT, String::toBoolean)
+
+/**
  * Reads the value for [Option.key] from the provided `options` or fallbacks to the [Option.defaultValue].
  */
 inline fun <T> Option<T>.get(configuration: Configuration, mapping: (String) -> T): T {

--- a/converter/src/test/kotlin/io/mcarle/konvert/converter/ConverterITest.kt
+++ b/converter/src/test/kotlin/io/mcarle/konvert/converter/ConverterITest.kt
@@ -2,10 +2,12 @@ package io.mcarle.konvert.converter
 
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
+import com.tschuchort.compiletesting.kspArgs
 import com.tschuchort.compiletesting.kspWithCompilation
 import com.tschuchort.compiletesting.symbolProcessorProviders
 import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.TypeConverterRegistry
+import io.mcarle.konvert.converter.api.config.ADD_GENERATED_KONVERTER_ANNOTATION_OPTION
 import io.mcarle.konvert.processor.KonvertProcessorProvider
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.config.JvmTarget
@@ -166,6 +168,7 @@ interface $mapperClassName {
             sources = sourceFiles
             verbose = false
             jvmTarget = JvmTarget.JVM_17.description
+            kspArgs += (ADD_GENERATED_KONVERTER_ANNOTATION_OPTION.key to "false")
             kspWithCompilation = true
         }
 

--- a/docs/options/index.adoc
+++ b/docs/options/index.adoc
@@ -103,6 +103,35 @@ class PersonDto(val name: String)
 Will generate a file `Person_XX.kt` instead of `PersonKonverter.kt`
 ====
 
+a|`*konvert.add-generated-konverter-annotation*`
+a|`true`/`false`
+a|`true`
+a|This setting will add the `@GeneratedKonverter` annotation on the generated functions. Together with a file being written to META-INF containing all generated functions FQN, this annotation is used to reuse previously generated konverter functions from other modules or libraries.
+If you do not want your generated konverter functions to be reused in other modules, you can turn this setting globally or per annotation.
+
+4+a|
+[.pl-6]
+.Example
+[%collapsible]
+====
+[source,kotlin]
+----
+@KonvertTo(PersonDto::class, priority = 123)
+class Person(val name: String)
+@KonvertTo(Person::class, options=[
+    Konfig(key="konvert.add-generated-konverter-annotation", value="false")
+])
+class PersonDto(val name: String)
+----
+Will generate:
+[source,kotlin]
+----
+@GeneratedKonverter(priority = 123)
+fun Person.toPersonDto() = PersonDto(name = name)
+fun PersonDto.toPerson() = Person(name = name)
+----
+====
+
 |===
 
 === `@Konverter` Options

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -39,3 +39,9 @@ ksp {
 tasks.test {
     useJUnitPlatform()
 }
+
+kover {
+    excludeSourceSets {
+        names(sourceSets.testFixtures.name)
+    }
+}

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/AnnotatedConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/AnnotatedConverter.kt
@@ -2,6 +2,10 @@ package io.mcarle.konvert.processor
 
 import io.mcarle.konvert.converter.api.TypeConverter
 
-interface AnnotatedConverterData {
-    fun toTypeConverters(): List<TypeConverter>
+fun interface AnnotatedConverterData {
+    fun toTypeConverters(): List<AnnotatedConverter>
+}
+
+interface AnnotatedConverter: TypeConverter {
+    val alreadyGenerated: Boolean
 }

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/GeneratedKonverterLoader.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/GeneratedKonverterLoader.kt
@@ -1,0 +1,107 @@
+package io.mcarle.konvert.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.closestClassDeclaration
+import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.getFunctionDeclarationsByName
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import io.mcarle.konvert.api.GeneratedKonverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.KonvertFrom
+import io.mcarle.konvert.api.KonvertTo
+import io.mcarle.konvert.api.Priority
+import io.mcarle.konvert.converter.api.TypeConverter
+import io.mcarle.konvert.converter.api.classDeclaration
+import io.mcarle.konvert.processor.konvert.KonvertTypeConverter
+import io.mcarle.konvert.processor.konvertfrom.KonvertFromTypeConverter
+import io.mcarle.konvert.processor.konvertto.KonvertToTypeConverter
+
+class GeneratedKonverterLoader(
+    private val resolver: Resolver,
+    private val logger: KSPLogger
+) {
+
+    fun load(): List<TypeConverter> {
+        return loadKonvertTypeConverter() + loadKonvertToTypeConverter() + loadKonvertFromTypeConverter()
+    }
+
+    private fun <T : TypeConverter> load(
+        resourceFile: String,
+        processor: (GeneratedKonverterData) -> T
+    ): List<T> {
+        return ClassLoader.getSystemResources(resourceFile)
+            .toList()
+            .flatMap { it.readText().lineSequence() }
+            .filter { it.isNotBlank() }
+            .flatMap { GeneratedKonverterData.from(it, resolver, logger) }
+            .map(processor)
+    }
+
+    private fun loadKonvertTypeConverter(): List<KonvertTypeConverter> {
+        return load("META-INF/konvert/io.mcarle.konvert.api.${Konvert::class.simpleName}") { data ->
+            KonvertTypeConverter(
+                priority = data.priority,
+                alreadyGenerated = true,
+                sourceType = data.function.parameters.first().type.resolve(),
+                targetType = data.function.returnType!!.resolve(),
+                mapFunctionName = data.function.simpleName.asString(),
+                paramName = data.function.parameters.first().name!!.asString(),
+                mapKSClassDeclaration = data.function.closestClassDeclaration()?.superTypes?.first()?.resolve()
+                    ?.classDeclaration()!!
+            )
+        }
+    }
+
+    private fun loadKonvertToTypeConverter(): List<KonvertToTypeConverter> {
+        return load("META-INF/konvert/io.mcarle.konvert.api.${KonvertTo::class.simpleName}") { data ->
+            KonvertToTypeConverter(
+                priority = data.priority,
+                alreadyGenerated = true,
+                mapFunctionName = data.function.simpleName.asString(),
+                sourceClassDeclaration = data.function.extensionReceiver!!.resolve().classDeclaration()!!,
+                targetClassDeclaration = data.function.returnType!!.resolve().classDeclaration()!!
+            )
+        }
+    }
+
+    private fun loadKonvertFromTypeConverter(): List<KonvertFromTypeConverter> {
+        return load("META-INF/konvert/io.mcarle.konvert.api.${KonvertFrom::class.simpleName}") { data ->
+            KonvertFromTypeConverter(
+                priority = data.priority,
+                alreadyGenerated = true,
+                mapFunctionName = data.function.simpleName.asString(),
+                paramName = data.function.parameters.first().name!!.asString(),
+                sourceClassDeclaration = data.function.parameters.first().typeClassDeclaration()!!,
+                targetClassDeclaration = data.function.returnType!!.resolve().classDeclaration()!!
+            )
+        }
+    }
+
+    data class GeneratedKonverterData(
+        val function: KSFunctionDeclaration,
+        val priority: Priority,
+    ) {
+
+        companion object {
+            @OptIn(KspExperimental::class)
+            fun from(fqn: String, resolver: Resolver, logger: KSPLogger): Sequence<GeneratedKonverterData> =
+                resolver.getFunctionDeclarationsByName(fqn, true).mapNotNull {
+                    val priority = it.getAnnotationsByType(GeneratedKonverter::class)
+                        .firstOrNull()
+                        ?.priority
+
+                    if (priority != null) {
+                        GeneratedKonverterData(
+                            function = it,
+                            priority = priority
+                        )
+                    } else {
+                        logger.logging("Ignoring $fqn, as there is no ${GeneratedKonverter::class.simpleName} annotation")
+                        null
+                    }
+                }
+        }
+    }
+}

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/GeneratedKonverterWriter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/GeneratedKonverterWriter.kt
@@ -1,0 +1,55 @@
+package io.mcarle.konvert.processor
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.KonvertFrom
+import io.mcarle.konvert.api.KonvertTo
+import io.mcarle.konvert.processor.konvert.KonverterCodeGenerator
+import io.mcarle.konvert.processor.konvert.KonverterData
+import io.mcarle.konvert.processor.konvertfrom.KonvertFromCodeGenerator
+import io.mcarle.konvert.processor.konvertfrom.KonvertFromData
+import io.mcarle.konvert.processor.konvertto.KonvertToCodeGenerator
+import io.mcarle.konvert.processor.konvertto.KonvertToData
+
+class GeneratedKonverterWriter(
+    private val codeGenerator: CodeGenerator,
+    private val logger: KSPLogger
+) {
+
+    fun write(converterData: List<AnnotatedConverterData>) {
+        writeMetaInfFile(
+            lines = converterData.filterIsInstance<KonverterData>().flatMap {
+                KonverterCodeGenerator.toFunctionFullyQualifiedNames(it)
+            }.toSet(),
+            konverterType = Konvert::class.java.simpleName
+        )
+        writeMetaInfFile(
+            lines = converterData.filterIsInstance<KonvertToData>().flatMap {
+                KonvertToCodeGenerator.toFunctionFullyQualifiedNames(it)
+            }.toSet(),
+            konverterType = KonvertTo::class.java.simpleName
+        )
+        writeMetaInfFile(
+            lines = converterData.filterIsInstance<KonvertFromData>().flatMap {
+                KonvertFromCodeGenerator.toFunctionFullyQualifiedNames(it)
+            }.toSet(),
+            konverterType = KonvertFrom::class.java.simpleName
+        )
+    }
+
+    private fun writeMetaInfFile(lines: Set<String>, konverterType: String) {
+        if (lines.isEmpty()) return
+        val output = codeGenerator.createNewFile(
+            dependencies = Dependencies.ALL_FILES,
+            packageName = "META-INF/konvert",
+            fileName = "io.mcarle.konvert.api",
+            extensionName = konverterType
+        )
+        output.bufferedWriter().use { writer ->
+            lines.forEach { writer.write(it + "\n") }
+        }
+    }
+
+}

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
@@ -7,6 +7,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeReference
+import io.mcarle.konvert.api.DEFAULT_KONVERTER_PRIORITY
 import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Mapping
@@ -27,6 +28,8 @@ class KonvertData(
     val targetClassDeclaration: KSClassDeclaration = targetType.classDeclaration()!!
     val mapFunctionName: String = mapKSFunctionDeclaration.simpleName.asString()
     val paramName: String = mapKSFunctionDeclaration.parameters.first().name!!.asString()
+
+    val priority = annotationData?.priority ?: DEFAULT_KONVERTER_PRIORITY
 
     data class AnnotationData(
         val mappings: List<Mapping>,

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertTypeConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertTypeConverter.kt
@@ -8,15 +8,17 @@ import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.isNullable
+import io.mcarle.konvert.processor.AnnotatedConverter
 
 class KonvertTypeConverter constructor(
     override val priority: Priority,
+    override val alreadyGenerated: Boolean,
     internal val sourceType: KSType,
     internal val targetType: KSType,
     internal val mapFunctionName: String,
     internal val paramName: String,
     internal val mapKSClassDeclaration: KSClassDeclaration
-) : AbstractTypeConverter() {
+) : AbstractTypeConverter(), AnnotatedConverter {
 
     override val enabledByDefault: Boolean = true
 

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
@@ -68,7 +68,7 @@ object KonverterCodeGenerator {
                     }
 
                 codeBuilder.addFunction(
-                    funSpec = FunSpec.builder(konvertData.mapFunctionName)
+                    funBuilder = FunSpec.builder(konvertData.mapFunctionName)
                         .addModifiers(KModifier.OVERRIDE)
                         .returns(konvertData.targetTypeReference.toTypeName())
                         .addParameter(konvertData.paramName, konvertData.sourceTypeReference.toTypeName())
@@ -82,8 +82,8 @@ object KonverterCodeGenerator {
                                 konvertData.targetType,
                                 konvertData.mapKSFunctionDeclaration
                             )
-                        )
-                        .build(),
+                        ),
+                    priority = konvertData.priority,
                     toType = true,
                     originating = data.mapKSClassDeclaration.containingFile
                 )
@@ -112,6 +112,17 @@ object KonverterCodeGenerator {
                     }
                 }
 
+        }
+    }
+
+    fun toFunctionFullyQualifiedNames(data: KonverterData): List<String> {
+        val qualifiedName = data.mapKSClassDeclaration.qualifiedName?.asString()
+        return data.konvertData.map {
+            if (qualifiedName.isNullOrEmpty()) {
+                it.mapFunctionName
+            } else {
+                "$qualifiedName.${it.mapFunctionName}"
+            }
         }
     }
 

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
@@ -116,13 +116,8 @@ object KonverterCodeGenerator {
     }
 
     fun toFunctionFullyQualifiedNames(data: KonverterData): List<String> {
-        val qualifiedName = data.mapKSClassDeclaration.qualifiedName?.asString()
         return data.konvertData.map {
-            if (qualifiedName.isNullOrEmpty()) {
-                it.mapFunctionName
-            } else {
-                "$qualifiedName.${it.mapFunctionName}"
-            }
+           "${data.mapKSClassDeclaration.qualifiedName?.asString()}.${it.mapFunctionName}"
         }
     }
 

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterData.kt
@@ -3,11 +3,10 @@ package io.mcarle.konvert.processor.konvert
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import io.mcarle.konvert.api.DEFAULT_KONVERTER_PRIORITY
 import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
-import io.mcarle.konvert.converter.api.TypeConverter
+import io.mcarle.konvert.processor.AnnotatedConverter
 import io.mcarle.konvert.processor.AnnotatedConverterData
 import io.mcarle.konvert.processor.from
 
@@ -17,10 +16,11 @@ class KonverterData(
     val mapKSClassDeclaration: KSClassDeclaration
 ) : AnnotatedConverterData {
 
-    override fun toTypeConverters(): List<TypeConverter> {
+    override fun toTypeConverters(): List<AnnotatedConverter> {
         return konvertData.map {
             KonvertTypeConverter(
-                priority = it.annotationData?.priority ?: DEFAULT_KONVERTER_PRIORITY,
+                priority = it.priority,
+                alreadyGenerated = false,
                 sourceType = it.sourceType,
                 targetType = it.targetType,
                 mapFunctionName = it.mapFunctionName,

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromCodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromCodeGenerator.kt
@@ -24,7 +24,7 @@ object KonvertFromCodeGenerator {
         )
 
         codeBuilder.addFunction(
-            funSpec = FunSpec.builder(data.mapFunctionName)
+            funBuilder = FunSpec.builder(data.mapFunctionName)
                 .returns(data.targetClassDeclaration.asStarProjectedType().toTypeName())
                 .addParameter(data.paramName, data.sourceClassDeclaration.asStarProjectedType().toTypeName())
                 .receiver(data.targetCompanionDeclaration.asStarProjectedType().toTypeName())
@@ -38,10 +38,21 @@ object KonvertFromCodeGenerator {
                         data.targetClassDeclaration.asStarProjectedType(),
                         data.targetCompanionDeclaration
                     )
-                )
-                .build(),
+                ),
+            priority = data.priority,
             toType = false,
             originating = data.targetClassDeclaration.containingFile
+        )
+    }
+
+    fun toFunctionFullyQualifiedNames(data: KonvertFromData): List<String> {
+        val packageName = data.targetClassDeclaration.packageName.asString()
+        return listOf(
+            if (packageName.isEmpty()) {
+                data.mapFunctionName
+            } else {
+                "$packageName.${data.mapFunctionName}"
+            }
         )
     }
 

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromData.kt
@@ -7,8 +7,8 @@ import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.Mapping
 import io.mcarle.konvert.api.Priority
-import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.classDeclaration
+import io.mcarle.konvert.processor.AnnotatedConverter
 import io.mcarle.konvert.processor.AnnotatedConverterData
 import io.mcarle.konvert.processor.from
 import java.util.Locale
@@ -23,10 +23,13 @@ class KonvertFromData(
     val mapFunctionName: String = annotationData.mapFunctionName.ifEmpty { "from${sourceClassDeclaration.simpleName.asString()}" }
     val paramName: String = sourceClassDeclaration.simpleName.asString().replaceFirstChar { it.lowercase(Locale.getDefault()) }
 
-    override fun toTypeConverters(): List<TypeConverter> {
+    val priority = annotationData.priority
+
+    override fun toTypeConverters(): List<AnnotatedConverter> {
         return listOf(
             KonvertFromTypeConverter(
-                priority = annotationData.priority,
+                priority = priority,
+                alreadyGenerated = false,
                 mapFunctionName = mapFunctionName,
                 paramName = paramName,
                 sourceClassDeclaration = sourceClassDeclaration,

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromTypeConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromTypeConverter.kt
@@ -3,17 +3,21 @@ package io.mcarle.konvert.processor.konvertfrom
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ksp.toClassName
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.isNullable
+import io.mcarle.konvert.processor.AnnotatedConverter
 
 class KonvertFromTypeConverter constructor(
     override val priority: Priority,
+    override val alreadyGenerated: Boolean,
     internal val mapFunctionName: String,
     internal val paramName: String,
     internal val sourceClassDeclaration: KSClassDeclaration,
     internal val targetClassDeclaration: KSClassDeclaration,
-) : AbstractTypeConverter() {
+) : AbstractTypeConverter(), AnnotatedConverter {
 
     private val sourceType: KSType = sourceClassDeclaration.asStarProjectedType()
     private val targetType: KSType = targetClassDeclaration.asStarProjectedType()
@@ -29,10 +33,12 @@ class KonvertFromTypeConverter constructor(
     override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         return CodeBlock.of(
             if (source.isNullable()) {
-                "$fieldName?.let·{ ${targetClassDeclaration.qualifiedName?.asString()}.$mapFunctionName($paramName·=·it) }"
+                "$fieldName?.let·{ %T.%M($paramName·=·it) }"
             } else {
-                "${targetClassDeclaration.qualifiedName?.asString()}.$mapFunctionName($paramName·=·$fieldName)"
-            } + appendNotNullAssertionOperatorIfNeeded(source, target)
+                "%T.%M($paramName·=·$fieldName)"
+            } + appendNotNullAssertionOperatorIfNeeded(source, target),
+            targetClassDeclaration.toClassName(),
+            MemberName(targetClassDeclaration.packageName.asString(), mapFunctionName)
         )
     }
 }

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToCodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToCodeGenerator.kt
@@ -31,7 +31,7 @@ object KonvertToCodeGenerator {
             }
 
         fileSpecBuilder.addFunction(
-            funSpec = FunSpec.builder(data.mapFunctionName)
+            funBuilder = FunSpec.builder(data.mapFunctionName)
                 .returns(data.targetClassDeclaration.asStarProjectedType().toTypeName())
                 .receiver(data.sourceClassDeclaration.asStarProjectedType().toTypeName())
                 .addCode(
@@ -44,12 +44,23 @@ object KonvertToCodeGenerator {
                         data.targetClassDeclaration.asStarProjectedType(),
                         data.sourceClassDeclaration
                     )
-                )
-                .build(),
+                ),
+            priority = data.priority,
             toType = false,
             originating = data.sourceClassDeclaration.containingFile
         )
 
+    }
+
+    fun toFunctionFullyQualifiedNames(data: KonvertToData): List<String> {
+        val packageName = data.sourceClassDeclaration.packageName.asString()
+        return listOf(
+            if (packageName.isEmpty()) {
+                data.mapFunctionName
+            } else {
+                "$packageName.${data.mapFunctionName}"
+            }
+        )
     }
 
 }

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToData.kt
@@ -8,8 +8,8 @@ import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
 import io.mcarle.konvert.api.Priority
-import io.mcarle.konvert.converter.api.TypeConverter
 import io.mcarle.konvert.converter.api.classDeclaration
+import io.mcarle.konvert.processor.AnnotatedConverter
 import io.mcarle.konvert.processor.AnnotatedConverterData
 import io.mcarle.konvert.processor.from
 
@@ -20,11 +20,14 @@ class KonvertToData(
 ) : AnnotatedConverterData {
 
     val mapFunctionName: String = annotationData.mapFunctionName.ifEmpty { "to${targetClassDeclaration.toClassName().simpleName}" }
+    val priority = annotationData.priority
 
-    override fun toTypeConverters(): List<TypeConverter> {
+
+    override fun toTypeConverters(): List<AnnotatedConverter> {
         return listOf(
             KonvertToTypeConverter(
-                priority = annotationData.priority,
+                priority = priority,
+                alreadyGenerated = false,
                 mapFunctionName = mapFunctionName,
                 sourceClassDeclaration = sourceClassDeclaration,
                 targetClassDeclaration = targetClassDeclaration

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToTypeConverter.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToTypeConverter.kt
@@ -3,16 +3,19 @@ package io.mcarle.konvert.processor.konvertto
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.MemberName
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.AbstractTypeConverter
 import io.mcarle.konvert.converter.api.isNullable
+import io.mcarle.konvert.processor.AnnotatedConverter
 
 class KonvertToTypeConverter constructor(
     override val priority: Priority,
+    override val alreadyGenerated: Boolean,
     internal val mapFunctionName: String,
     internal val sourceClassDeclaration: KSClassDeclaration,
     internal val targetClassDeclaration: KSClassDeclaration,
-) : AbstractTypeConverter() {
+) : AbstractTypeConverter(), AnnotatedConverter {
 
     private val sourceType: KSType = sourceClassDeclaration.asStarProjectedType()
     private val targetType: KSType = targetClassDeclaration.asStarProjectedType()
@@ -28,7 +31,8 @@ class KonvertToTypeConverter constructor(
     override fun convert(fieldName: String, source: KSType, target: KSType): CodeBlock {
         val nc = if (source.isNullable()) "?" else ""
         return CodeBlock.of(
-            "$fieldName$nc.$mapFunctionName()" + appendNotNullAssertionOperatorIfNeeded(source, target)
+            "$fieldName$nc.%M()" + appendNotNullAssertionOperatorIfNeeded(source, target),
+            MemberName(sourceClassDeclaration.packageName.asString(), mapFunctionName)
         )
     }
 

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/GeneratedKonverterITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/GeneratedKonverterITest.kt
@@ -1,0 +1,401 @@
+package io.mcarle.konvert.processor
+
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.tschuchort.compiletesting.SourceFile
+import io.mcarle.konvert.api.GeneratedKonverter
+import io.mcarle.konvert.converter.SameTypeConverter
+import io.mcarle.konvert.converter.api.TypeConverterRegistry
+import io.mcarle.konvert.converter.api.config.ADD_GENERATED_KONVERTER_ANNOTATION_OPTION
+import io.mcarle.konvert.processor.konvert.KonvertTypeConverter
+import io.mcarle.konvert.processor.konvertfrom.KonvertFromTypeConverter
+import io.mcarle.konvert.processor.konvertto.KonvertToTypeConverter
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class GeneratedKonverterITest : KonverterITest() {
+
+    override var addGeneratedKonverterAnnotation = true
+
+    @Test
+    fun loadGeneratedKonvertTypeConverter() {
+        super.compileWith(emptyList())
+        val alreadyGeneratedKonverterList = TypeConverterRegistry
+            .filterIsInstance<KonvertTypeConverter>()
+            .filter { it.alreadyGenerated }
+        assertEquals(1, alreadyGeneratedKonverterList.size, "missing generated konverter")
+        val converter = alreadyGeneratedKonverterList.first()
+        assertEquals("toSomeOtherTestClass", converter.mapFunctionName)
+        assertEquals("SomeTestClass", converter.sourceType.toClassName().simpleName)
+        assertEquals("SomeOtherTestClass", converter.targetType.toClassName().simpleName)
+        assertEquals("source", converter.paramName)
+        assertEquals("SomeTestMapper", converter.mapKSClassDeclaration.simpleName.asString())
+        assertEquals(true, converter.enabledByDefault)
+        assertEquals(12, converter.priority)
+    }
+
+    @Test
+    fun loadGeneratedKonvertToTypeConverter() {
+        super.compileWith(emptyList())
+        val alreadyGeneratedKonverterList = TypeConverterRegistry
+            .filterIsInstance<KonvertToTypeConverter>()
+            .filter { it.alreadyGenerated }
+        assertEquals(1, alreadyGeneratedKonverterList.size, "missing generated konverter")
+        val converter = alreadyGeneratedKonverterList.first()
+        assertEquals("toSomeOtherTestClass", converter.mapFunctionName)
+        assertEquals("SomeTestClass", converter.sourceClassDeclaration.simpleName.asString())
+        assertEquals("SomeOtherTestClass", converter.targetClassDeclaration.simpleName.asString())
+        assertEquals(true, converter.enabledByDefault)
+        assertEquals(10, converter.priority)
+    }
+
+    @Test
+    fun loadGeneratedKonvertFromTypeConverter() {
+        super.compileWith(emptyList())
+        val alreadyGeneratedKonverterList = TypeConverterRegistry
+            .filterIsInstance<KonvertFromTypeConverter>()
+            .filter { it.alreadyGenerated }
+        assertEquals(1, alreadyGeneratedKonverterList.size, "missing generated konverter")
+        val converter = alreadyGeneratedKonverterList.first()
+        assertEquals("fromSomeTestClass", converter.mapFunctionName)
+        assertEquals("SomeTestClass", converter.sourceClassDeclaration.simpleName.asString())
+        assertEquals("SomeOtherTestClass", converter.targetClassDeclaration.simpleName.asString())
+        assertEquals("source", converter.paramName)
+        assertEquals(true, converter.enabledByDefault)
+        assertEquals(11, converter.priority)
+    }
+
+    @Test
+    fun useGeneratedKonverterWithHighestPriority() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.KonvertTo
+import io.mcarle.konvert.processor.SomeTestClass
+import io.mcarle.konvert.processor.SomeOtherTestClass
+
+@KonvertTo(TargetClass::class)
+class SourceClass(val property: SomeTestClass)
+class TargetClass(val property: SomeOtherTestClass)
+
+                """.trimIndent()
+            )
+        )
+        val extensionFunctionCode = compilation.generatedSourceFor("SourceClassKonverter.kt")
+        println(extensionFunctionCode)
+
+        assertSourceEquals(
+            """
+            import io.mcarle.konvert.api.GeneratedKonverter
+            import io.mcarle.konvert.processor.toSomeOtherTestClass
+
+            @GeneratedKonverter(priority = 3_000)
+            public fun SourceClass.toTargetClass(): TargetClass = TargetClass(
+              property = property.toSomeOtherTestClass()
+            )
+            """.trimIndent(),
+            extensionFunctionCode
+        )
+    }
+
+    @Test
+    fun generateGeneratedKonverterAnnotationForKonvertTo() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.KonvertTo
+
+@KonvertTo(TargetClass::class, priority = 123)
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+                """.trimIndent()
+            )
+        )
+        val extensionFunctionCode = compilation.generatedSourceFor("SourceClassKonverter.kt")
+        println(extensionFunctionCode)
+
+        assertSourceEquals(
+            """
+            import io.mcarle.konvert.api.GeneratedKonverter
+
+            @GeneratedKonverter(priority = 123)
+            public fun SourceClass.toTargetClass(): TargetClass = TargetClass(
+              property = property
+            )
+            """.trimIndent(),
+            extensionFunctionCode
+        )
+    }
+
+    @Test
+    fun generateGeneratedKonverterAnnotationForKonvertFrom() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.KonvertFrom
+
+class SourceClass(val property: String)
+
+@KonvertFrom(SourceClass::class, priority = 123)
+class TargetClass(val property: String) {
+    companion object
+}
+                """.trimIndent()
+            )
+        )
+        val extensionFunctionCode = compilation.generatedSourceFor("TargetClassKonverter.kt")
+        println(extensionFunctionCode)
+
+        assertSourceEquals(
+            """
+            import io.mcarle.konvert.api.GeneratedKonverter
+
+            @GeneratedKonverter(priority = 123)
+            public fun TargetClass.Companion.fromSourceClass(sourceClass: SourceClass): TargetClass =
+                TargetClass(
+              property = sourceClass.property
+            )
+            """.trimIndent(),
+            extensionFunctionCode
+        )
+    }
+
+    @Test
+    fun generateGeneratedKonverterAnnotationForKonverter() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+
+@Konverter
+interface Mapper {
+    @Konvert(priority = 123)
+    fun toTarget(source: SourceClass): TargetClass
+}
+                """.trimIndent()
+            )
+        )
+        val extensionFunctionCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(extensionFunctionCode)
+
+        assertSourceEquals(
+            """
+            import io.mcarle.konvert.api.GeneratedKonverter
+
+            public object MapperImpl : Mapper {
+              @GeneratedKonverter(priority = 123)
+              override fun toTarget(source: SourceClass): TargetClass = TargetClass(
+                property = source.property
+              )
+            }
+            """.trimIndent(),
+            extensionFunctionCode
+        )
+    }
+
+    @Test
+    fun doNotGenerateGeneratedKonverterAnnotationIfOptionDisabledInKonvertToOptions() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.KonvertTo
+import io.mcarle.konvert.api.Konfig
+
+@KonvertTo(TargetClass::class, options=[Konfig(key = "${ADD_GENERATED_KONVERTER_ANNOTATION_OPTION.key}", value = "false")])
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+                """.trimIndent()
+            )
+        )
+        val extensionFunctionCode = compilation.generatedSourceFor("SourceClassKonverter.kt")
+        println(extensionFunctionCode)
+
+        assertSourceEquals(
+            """
+            public fun SourceClass.toTargetClass(): TargetClass = TargetClass(
+              property = property
+            )
+            """.trimIndent(),
+            extensionFunctionCode
+        )
+    }
+
+    @Test
+    fun doNotGenerateGeneratedKonverterAnnotationIfOptionDisabledInKonvertFromOptions() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.KonvertFrom
+import io.mcarle.konvert.api.Konfig
+
+class SourceClass(val property: String)
+
+@KonvertFrom(SourceClass::class, options=[Konfig(key = "${ADD_GENERATED_KONVERTER_ANNOTATION_OPTION.key}", value = "false")])
+class TargetClass(val property: String) {
+    companion object
+}
+                """.trimIndent()
+            )
+        )
+        val extensionFunctionCode = compilation.generatedSourceFor("TargetClassKonverter.kt")
+        println(extensionFunctionCode)
+
+        assertSourceEquals(
+            """
+            public fun TargetClass.Companion.fromSourceClass(sourceClass: SourceClass): TargetClass =
+                TargetClass(
+              property = sourceClass.property
+            )
+            """.trimIndent(),
+            extensionFunctionCode
+        )
+    }
+
+    @Test
+    fun doNotGenerateGeneratedKonverterAnnotationIfOptionDisabledInKonvertOptions() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konfig
+
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+
+@Konverter
+interface Mapper {
+    @Konvert(options=[Konfig(key = "${ADD_GENERATED_KONVERTER_ANNOTATION_OPTION.key}", value = "false")])
+    fun toTarget(source: SourceClass): TargetClass
+}
+                """.trimIndent()
+            )
+        )
+        val extensionFunctionCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(extensionFunctionCode)
+
+        assertSourceEquals(
+            """
+            public object MapperImpl : Mapper {
+              override fun toTarget(source: SourceClass): TargetClass = TargetClass(
+                property = source.property
+              )
+            }
+            """.trimIndent(),
+            extensionFunctionCode
+        )
+    }
+
+    @Test
+    fun doNotGenerateGeneratedKonverterAnnotationIfOptionDisabledInKonverterOptions() {
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konfig
+
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+
+@Konverter(options=[Konfig(key = "${ADD_GENERATED_KONVERTER_ANNOTATION_OPTION.key}", value = "false")])
+interface Mapper {
+    fun toTarget(source: SourceClass): TargetClass
+}
+                """.trimIndent()
+            )
+        )
+        val extensionFunctionCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(extensionFunctionCode)
+
+        assertSourceEquals(
+            """
+            public object MapperImpl : Mapper {
+              override fun toTarget(source: SourceClass): TargetClass = TargetClass(
+                property = source.property
+              )
+            }
+            """.trimIndent(),
+            extensionFunctionCode
+        )
+    }
+
+}
+
+
+data class SomeTestClass(val s: String)
+data class SomeOtherTestClass(val s: Int) {
+    companion object
+}
+
+interface SomeTestMapper {
+    fun toSomeOtherTestClass(source: SomeTestClass): SomeOtherTestClass
+}
+
+/**
+ * Is referenced by META-INF/konvert/io.mcarle.konvert.api.KonvertTo
+ */
+@GeneratedKonverter(priority = 10)
+fun SomeTestClass.toSomeOtherTestClass() = SomeOtherTestClass(s.toInt())
+
+/**
+ * Is referenced by META-INF/konvert/io.mcarle.konvert.api.KonvertFrom
+ */
+@GeneratedKonverter(priority = 11)
+fun SomeOtherTestClass.Companion.fromSomeTestClass(source: SomeTestClass) = SomeOtherTestClass(
+    source.s.toInt()
+)
+
+object SomeTestMapperImpl : SomeTestMapper {
+    /**
+     * Is referenced by META-INF/konvert/io.mcarle.konvert.api.Konvert
+     */
+    @GeneratedKonverter(priority = 12)
+    override fun toSomeOtherTestClass(source: SomeTestClass): SomeOtherTestClass {
+        return SomeOtherTestClass(source.s.toInt())
+    }
+}
+
+

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/MetaInfKonverterResourcesITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/MetaInfKonverterResourcesITest.kt
@@ -1,0 +1,128 @@
+package io.mcarle.konvert.processor
+
+import com.tschuchort.compiletesting.SourceFile
+import io.mcarle.konvert.converter.SameTypeConverter
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class MetaInfKonverterResourcesITest : KonverterITest() {
+
+    override var addGeneratedKonverterAnnotation = true
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "a.b"])
+    fun generateKonvertToFile(packageName: String) {
+        val codeFileName = packageName.replace(".", "/").let {
+            (if (it.isNotEmpty()) "$it/" else it) + "TestCode.kt"
+        }
+        val packageCodeLine = if (packageName.isNotEmpty()) "package $packageName" else ""
+        val expectedPackagePrefix = packageName + if (packageName.isNotEmpty()) "." else ""
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = codeFileName,
+                contents =
+                """
+$packageCodeLine
+import io.mcarle.konvert.api.KonvertTo
+
+@KonvertTo(TargetClass::class)
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+
+                """.trimIndent()
+            )
+        )
+        val metaInfFileContent = compilation.generatedSourceFor("io.mcarle.konvert.api.KonvertTo")
+        println(metaInfFileContent)
+
+        assertContentEquals(
+            """
+            ${expectedPackagePrefix}toTargetClass
+            """.trimIndent(),
+            metaInfFileContent
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "a.b"])
+    fun generateKonvertFromFile(packageName: String) {
+        val codeFileName = packageName.replace(".", "/").let {
+            (if (it.isNotEmpty()) "$it/" else it) + "TestCode.kt"
+        }
+        val packageCodeLine = if (packageName.isNotEmpty()) "package $packageName" else ""
+        val expectedPackagePrefix = packageName + if (packageName.isNotEmpty()) "." else ""
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = codeFileName,
+                contents =
+                """
+$packageCodeLine
+import io.mcarle.konvert.api.KonvertFrom
+
+class SourceClass(val property: String)
+@KonvertFrom(SourceClass::class)
+class TargetClass(val property: String) {
+    companion object
+}
+
+                """.trimIndent()
+            )
+        )
+        val metaInfFileContent = compilation.generatedSourceFor("io.mcarle.konvert.api.KonvertFrom")
+        println(metaInfFileContent)
+
+        assertContentEquals(
+            """
+            ${expectedPackagePrefix}fromSourceClass
+            """.trimIndent(),
+            metaInfFileContent
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "a.b"])
+    fun generateKonvertFile(packageName: String) {
+        val codeFileName = packageName.replace(".", "/").let {
+            (if (it.isNotEmpty()) "$it/" else it) + "TestCode.kt"
+        }
+        val packageCodeLine = if (packageName.isNotEmpty()) "package $packageName" else ""
+        val expectedPackagePrefix = packageName + if (packageName.isNotEmpty()) "." else ""
+        val (compilation) = super.compileWith(
+            listOf(SameTypeConverter()),
+            emptyList(),
+            true,
+            SourceFile.kotlin(
+                name = codeFileName,
+                contents =
+                """
+$packageCodeLine
+import io.mcarle.konvert.api.Konverter
+
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+
+@Konverter
+interface Mapper {
+    fun toTarget(source: SourceClass): TargetClass
+}
+                """.trimIndent()
+            )
+        )
+        val metaInfFileContent = compilation.generatedSourceFor("io.mcarle.konvert.api.Konvert")
+        println(metaInfFileContent)
+
+        assertContentEquals(
+            """
+            ${expectedPackagePrefix}Mapper.toTarget
+            """.trimIndent(),
+            metaInfFileContent
+        )
+    }
+
+}

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
@@ -55,7 +55,9 @@ interface Mapper {
         val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
         println(mapperCode)
 
-        val converter = TypeConverterRegistry.firstIsInstanceOrNull<KonvertTypeConverter>()
+        val converter = TypeConverterRegistry.filterIsInstance<KonvertTypeConverter>().firstOrNull {
+            !it.alreadyGenerated
+        }
         assertNotNull(converter, "No KonverterTypeConverter registered")
         assertEquals("toTarget", converter.mapFunctionName)
         assertEquals("source", converter.paramName)
@@ -93,7 +95,9 @@ interface Mapper {
         val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
         println(mapperCode)
 
-        val converter = TypeConverterRegistry.firstIsInstanceOrNull<KonvertTypeConverter>()
+        val converter = TypeConverterRegistry.filterIsInstance<KonvertTypeConverter>().firstOrNull {
+            !it.alreadyGenerated
+        }
         assertNotNull(converter, "No KonverterTypeConverter registered")
         assertEquals("toTarget", converter.mapFunctionName)
         assertEquals("source", converter.paramName)
@@ -132,7 +136,9 @@ interface Mapper {
         )
         assertThrows<IllegalArgumentException> { compilation.generatedSourceFor("MapperKonverter.kt") }
 
-        val converter = TypeConverterRegistry.firstIsInstanceOrNull<KonvertTypeConverter>()
+        val converter = TypeConverterRegistry.filterIsInstance<KonvertTypeConverter>().firstOrNull {
+            !it.alreadyGenerated
+        }
         assertNotNull(converter, "No KonverterTypeConverter registered")
         assertEquals("toTarget", converter.mapFunctionName)
         assertEquals("source", converter.paramName)

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromITest.kt
@@ -45,7 +45,9 @@ class TargetClass(
         val extensionFunctionCode = compilation.generatedSourceFor("TargetClassKonverter.kt")
         println(extensionFunctionCode)
 
-        val converter = TypeConverterRegistry.firstIsInstanceOrNull<KonvertFromTypeConverter>()
+        val converter = TypeConverterRegistry.filterIsInstance<KonvertFromTypeConverter>().firstOrNull {
+            !it.alreadyGenerated
+        }
         assertNotNull(converter, "No KonvertFromTypeConverter registered")
         assertEquals("fromSourceClass", converter.mapFunctionName)
         assertEquals("sourceClass", converter.paramName)
@@ -81,7 +83,9 @@ class TargetClass(
         val extensionFunctionCode = compilation.generatedSourceFor("TargetClassKonverter.kt")
         println(extensionFunctionCode)
 
-        val converter = TypeConverterRegistry.firstIsInstanceOrNull<KonvertFromTypeConverter>()
+        val converter = TypeConverterRegistry.filterIsInstance<KonvertFromTypeConverter>().firstOrNull {
+            !it.alreadyGenerated
+        }
         assertNotNull(converter, "No KonvertFromTypeConverter registered")
         assertEquals("fromSourceClass", converter.mapFunctionName)
         assertEquals("sourceClass", converter.paramName)

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
@@ -8,7 +8,6 @@ import io.mcarle.konvert.converter.api.TypeConverterRegistry
 import io.mcarle.konvert.converter.api.config.GENERATED_FILENAME_SUFFIX_OPTION
 import io.mcarle.konvert.processor.KonverterITest
 import io.mcarle.konvert.processor.generatedSourceFor
-import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -43,7 +42,9 @@ class TargetClass(
         val extensionFunctionCode = compilation.generatedSourceFor("SourceClassKonverter.kt")
         println(extensionFunctionCode)
 
-        val converter = TypeConverterRegistry.firstIsInstanceOrNull<KonvertToTypeConverter>()
+        val converter = TypeConverterRegistry.filterIsInstance<KonvertToTypeConverter>().firstOrNull {
+            !it.alreadyGenerated
+        }
         assertNotNull(converter, "No KonvertToTypeConverter registered")
         assertEquals("toTargetClass", converter.mapFunctionName)
         assertEquals("SourceClass", converter.sourceClassDeclaration.simpleName.asString())
@@ -147,13 +148,15 @@ class TargetProperty<E>(val value: E)
         val extensionFunctionCode = compilation.generatedSourceFor("SourceClassKonverter.kt")
         println(extensionFunctionCode)
 
-        assertSourceEquals("""
+        assertSourceEquals(
+            """
             import io.mcarle.konvert.api.Konverter
 
             public fun SourceClass.toTargetClass(): TargetClass = TargetClass(
               targetProperty = Konverter.get<KonvertInterface>().toTargetProperty(sourceProperty = sourceProperty)
             )
-        """.trimIndent(), extensionFunctionCode)
+        """.trimIndent(), extensionFunctionCode
+        )
     }
 
     @Test

--- a/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.Konvert
+++ b/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.Konvert
@@ -1,1 +1,2 @@
+thisLineShouldBeIgnoredAsNoFunctionExistsWithThisName
 io.mcarle.konvert.processor.SomeTestMapperImpl.toSomeOtherTestClass

--- a/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.Konvert
+++ b/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.Konvert
@@ -1,0 +1,1 @@
+io.mcarle.konvert.processor.SomeTestMapperImpl.toSomeOtherTestClass

--- a/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.KonvertFrom
+++ b/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.KonvertFrom
@@ -1,0 +1,1 @@
+io.mcarle.konvert.processor.fromSomeTestClass

--- a/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.KonvertTo
+++ b/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.KonvertTo
@@ -1,0 +1,1 @@
+io.mcarle.konvert.processor.toSomeOtherTestClass


### PR DESCRIPTION
This PR enables to use previously generated konverters from other modules or libraries.

To do this, each function is written into a file in META-INF/konvert/ during generation. On startup of processing, these functions are loaded and registered as TypeConverters and can therefore be used as normal.