### PR TITLE
build: add scripts for skip `testFixtures` in publish

### DIFF
--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -44,3 +44,7 @@ kover {
         names(sourceSets.testFixtures.name)
     }
 }
+
+val javaComponent = components["java"] as AdhocComponentWithVariants
+javaComponent.withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
+javaComponent.withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }


### PR DESCRIPTION
Add scripts to prevent `konvert-processor` from adding dependencies to `pom.xml` by the `java-test-fixes` plug-in.

resolve #22 