### PR TITLE
Fix konvert annotation for api <25

### DIFF
--- a/annotations/src/main/kotlin/io/mcarle/konvert/api/Konverter.kt
+++ b/annotations/src/main/kotlin/io/mcarle/konvert/api/Konverter.kt
@@ -67,7 +67,7 @@ annotation class Konverter(
                     }?.get(null)
 
                     if (implInstance == null) {
-                        implInstance = implClass.constructors.firstOrNull { it.parameterCount == 0 }?.newInstance()
+                        implInstance = implClass.constructors.firstOrNull { it.parameterTypes.isEmpty() }?.newInstance()
                             ?: throw RuntimeException("Could not determine INSTANCE or empty constructor for $implClass")
                     }
                     mappers[clazz] = implInstance


### PR DESCRIPTION
For android api <25 we are getting an error:

java.lang.NoSuchMethodError: No virtual method getParameterCount()I in class Ljava/lang/reflect/Constructor; or its super classes (declaration of 'java.lang.reflect.Constructor' appears in /system/framework/core-libart.jar)
                                                                                                 	
This change fixes the issue