### PR TITLE
feat: directly use interface implementations instead of requiring jvm reflection during runtime

### DIFF
--- a/annotations/src/main/kotlin/io/mcarle/konvert/api/Konverter.kt
+++ b/annotations/src/main/kotlin/io/mcarle/konvert/api/Konverter.kt
@@ -49,6 +49,10 @@ annotation class Konverter(
             this.CLASS_LOADER_LIST += classLoader
         }
 
+        fun removeClassLoader(classLoader: ClassLoader) {
+            this.CLASS_LOADER_LIST -= classLoader
+        }
+
         inline fun <reified T : Any> get(): T = get(T::class)
 
         @Suppress("UNCHECKED_CAST")

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/KonvertOptions.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/KonvertOptions.kt
@@ -21,6 +21,14 @@ object ENFORCE_NOT_NULL_OPTION : Option<Boolean>("konvert.enforce-not-null", fal
 object KONVERTER_GENERATE_CLASS_OPTION : Option<Boolean>("konvert.konverter.generate-class", false)
 
 /**
+ * When set to true, Konvert will use reflection to find implementations of @Konverter annotated interfaces at runtime instead of
+ * hard-coding them at ksp generation time.
+ *
+ * Default: false
+ */
+object KONVERTER_USE_REFLECTION_OPTION : Option<Boolean>("konvert.konverter.use-reflection", false)
+
+/**
  * This setting will change the suffix for the generated filename from Konvert.
  *
  * Given the following examples:

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/extensions.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/extensions.kt
@@ -15,6 +15,12 @@ val Configuration.Companion.konverterGenerateClass: Boolean
     get() = KONVERTER_GENERATE_CLASS_OPTION.get(CURRENT, String::toBoolean)
 
 /**
+ * @see KONVERTER_USE_REFLECTION_OPTION
+ */
+val Configuration.Companion.konverterUseReflection: Boolean
+    get() = KONVERTER_USE_REFLECTION_OPTION.get(CURRENT, String::toBoolean)
+
+/**
  * @see GENERATED_FILENAME_SUFFIX_OPTION
  */
 val Configuration.Companion.generatedFilenameSuffix: String

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -70,6 +70,7 @@
                         <plugin>ksp</plugin>
                     </compilerPlugins>
                     <pluginOptions>
+                        <!-- This is how you globally define options to Konvert -->
                         <option>ksp:apoption=konvert.konverter.generate-class=true</option>
                     </pluginOptions>
                 </configuration>

--- a/example/src/main/kotlin/io/mcarle/konvert/example/Mapper.kt
+++ b/example/src/main/kotlin/io/mcarle/konvert/example/Mapper.kt
@@ -1,20 +1,28 @@
 package io.mcarle.konvert.example
 
+import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.api.Mapping
+import io.mcarle.konvert.api.config.KONVERTER_GENERATE_CLASS
 import io.mcarle.konvert.api.converter.LONG_TO_UINT_CONVERTER
 import io.mcarle.konvert.api.converter.STRING_TO_INT_CONVERTER
 import io.mcarle.konvert.injector.spring.KComponent
 
-@Konverter
+@Konverter(options = [
+    /**
+     * This is already set in the pom.xml, but you can also define it here (and override default and global values with that).
+     */
+    Konfig(key = KONVERTER_GENERATE_CLASS, value = "true")
+])
 @KComponent
 interface Mapper {
     @Konvert(
         mappings = [
             Mapping(source = "streetName", target = "street"),
             Mapping(source = "zipCode", target = "zip")
-        ]
+        ],
+        priority = 1
     )
     fun fromDto(dto: AddressDto): Address
 

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:${Versions.jUnit}")
     testImplementation("org.junit.jupiter:junit-jupiter-params:${Versions.jUnit}")
     testImplementation(kotlinTest)
+    testImplementation(kotlinReflect)
     testFixturesApi(kotlinCompileTesting)
     testFixturesApi(kotlinCompileTestingKsp)
     testFixturesApi(kotlinCompilerEmbeddable)

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
@@ -39,8 +39,8 @@ object KonverterCodeGenerator {
                 withIsolatedConfiguration(konvertData.annotationData.options) {
                     if (isAlias(konvertData.sourceTypeReference, konvertData.sourceType)) {
                         // @Konverter annotated interface used alias for source, so the implementation should also use the same alias
-                        codeBuilder.addImport(konvertData.sourceType, konvertData.sourceTypeReference.toString())
-                    }
+                        codeBuilder.addImport(konvertData.sourceType, konvertData.sourceTypeReference.toString())}
+
                     val targetClassImportName =
                         if (isAlias(konvertData.targetTypeReference, konvertData.targetType)) {
                             // @Konverter annotated interface used alias for target, so the implementation should also use the same alias

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
@@ -83,37 +83,45 @@ object KonverterDataCollector {
                     KonvertData.AnnotationData.from(annotation)
                 }
 
-                if (annotation != null && it.isAbstract) {
-                    check(source != null && target != null) {
-                        "Konvert annotated function must have exactly one parameter and must have a return type: $it"
+                when {
+                    annotation != null && it.isAbstract -> {
+                        check(source != null && target != null) {
+                            "Konvert annotated function must have exactly one parameter and must have a return type: $it"
+                        }
+
+                        KonvertData(
+                            annotationData = annotation,
+                            isAbstract = true,
+                            sourceTypeReference = source,
+                            targetTypeReference = target,
+                            mapKSFunctionDeclaration = it,
+                            additionalParameters = determineAdditionalParams(it, sourceValueParameter)
+                        )
                     }
 
-                    KonvertData(
-                        annotationData = annotation,
-                        isAbstract = true,
-                        sourceTypeReference = source,
-                        targetTypeReference = target,
-                        mapKSFunctionDeclaration = it,
-                        additionalParameters = determineAdditionalParams(it, sourceValueParameter)
-                    )
-                } else if (source != null && target != null) {
-                    KonvertData(
-                        annotationData = annotation ?: KonvertData.AnnotationData.default(resolver, it.isAbstract),
-                        isAbstract = it.isAbstract,
-                        sourceTypeReference = source,
-                        targetTypeReference = target,
-                        mapKSFunctionDeclaration = it,
-                        additionalParameters = determineAdditionalParams(it, sourceValueParameter)
-                    )
-                } else if (it.isAbstract) {
-                    throw RuntimeException("Method $it is abstract and does not meet criteria for automatic source and target detection")
-                } else {
-                    if (annotation != null) {
-                        logger.warn("Could not determine source and/or target", it)
-                    } else {
-                        logger.logging("Could not determine source and/or target", it)
+                    source != null && target != null -> {
+                        KonvertData(
+                            annotationData = annotation ?: KonvertData.AnnotationData.default(resolver, it.isAbstract),
+                            isAbstract = it.isAbstract,
+                            sourceTypeReference = source,
+                            targetTypeReference = target,
+                            mapKSFunctionDeclaration = it,
+                            additionalParameters = determineAdditionalParams(it, sourceValueParameter)
+                        )
                     }
-                    null
+
+                    it.isAbstract -> {
+                        throw RuntimeException("Method $it is abstract and does not meet criteria for automatic source and target detection")
+                    }
+
+                    else -> {
+                        if (annotation != null) {
+                            logger.warn("Could not determine source and/or target", it)
+                        } else {
+                            logger.logging("Could not determine source and/or target", it)
+                        }
+                        null
+                    }
                 }
             }.toList()
     }

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterInterface.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterInterface.kt
@@ -10,4 +10,3 @@ data class KonverterInterface constructor(
     val packageName = kSClassDeclaration.packageName.asString()
     val typeName = kSClassDeclaration.asStarProjectedType().toTypeName()
 }
-

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToDataCollector.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToDataCollector.kt
@@ -15,10 +15,10 @@ object KonvertToDataCollector {
             .flatMap { ksAnnotated ->
                 val ksClassDeclaration = ksAnnotated as? KSClassDeclaration
                 check(ksClassDeclaration != null && ksClassDeclaration.classKind == ClassKind.CLASS) {
-                    "${KonvertTo::class.simpleName} can only target classes and companion objects"
+                    "@${KonvertTo::class.simpleName} can only target classes, but $ksAnnotated is not a class"
                 }
                 check(ksClassDeclaration.typeParameters.isEmpty()) {
-                    "${KonvertTo::class.simpleName} not allowed on types with generics: $ksAnnotated"
+                    "@${KonvertTo::class.simpleName} not allowed on types with generics: ${ksAnnotated.qualifiedName?.asString() ?: ksAnnotated}"
                 }
 
                 ksClassDeclaration.annotations

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/GeneratedKonverterITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/GeneratedKonverterITest.kt
@@ -23,33 +23,52 @@ class GeneratedKonverterITest : KonverterITest() {
         val alreadyGeneratedKonverterList = TypeConverterRegistry
             .filterIsInstance<KonvertTypeConverter>()
             .filter { it.alreadyGenerated }
-        assertEquals(3, alreadyGeneratedKonverterList.size, "missing generated konverter")
+        assertEquals(4, alreadyGeneratedKonverterList.size, "missing generated konverter")
         alreadyGeneratedKonverterList[0].let { converter ->
-            assertEquals("toSomeOtherTestClass", converter.mapFunctionName)
             assertEquals("SomeTestClass", converter.sourceType.toClassName().simpleName)
             assertEquals("SomeOtherTestClass", converter.targetType.toClassName().simpleName)
+
+            assertEquals("toSomeOtherTestClass", converter.mapFunctionName)
             assertEquals("source", converter.paramName)
             assertEquals("SomeTestMapper", converter.konverterInterface.simpleName)
             assertEquals(true, converter.enabledByDefault)
             assertEquals(12, converter.priority)
-        }
-        alreadyGeneratedKonverterList[2].let { converter ->
-            assertEquals("toSomeOtherTestClasses", converter.mapFunctionName)
-            assertEquals("List<SomeTestClass>", converter.sourceType.toString()) // toClassName() would here result in exception due to Resolver not initialized
-            assertEquals("List<SomeOtherTestClass>", converter.targetType.toString())  // toClassName() would here result in exception due to Resolver not initialized
-            assertEquals("source", converter.paramName)
-            assertEquals("SomeTestMapper", converter.konverterInterface.simpleName)
-            assertEquals(true, converter.enabledByDefault)
-            assertEquals(333, converter.priority)
+            assertEquals(KonvertTypeConverter.ClassOrObject.OBJECT, converter.classKind)
         }
         alreadyGeneratedKonverterList[1].let { converter ->
-            assertEquals("fromSomeOtherTestClass", converter.mapFunctionName)
             assertEquals("SomeOtherTestClass", converter.sourceType.toClassName().simpleName)
             assertEquals("SomeTestClass", converter.targetType.toClassName().simpleName)
+
+            assertEquals("fromSomeOtherTestClass", converter.mapFunctionName)
             assertEquals("source", converter.paramName)
             assertEquals("SomeTestMapper", converter.konverterInterface.simpleName)
             assertEquals(true, converter.enabledByDefault)
             assertEquals(123, converter.priority)
+            assertEquals(KonvertTypeConverter.ClassOrObject.OBJECT, converter.classKind)
+        }
+        alreadyGeneratedKonverterList[2].let { converter ->
+            // toClassName() would result in exception due to Resolver not initialized
+            assertEquals("List<SomeTestClass>",converter.sourceType.toString())
+            assertEquals("List<SomeOtherTestClass>",converter.targetType.toString())
+
+            assertEquals("toSomeOtherTestClasses", converter.mapFunctionName)
+            assertEquals("source", converter.paramName)
+            assertEquals("SomeTestMapper", converter.konverterInterface.simpleName)
+            assertEquals(true, converter.enabledByDefault)
+            assertEquals(333, converter.priority)
+            assertEquals(KonvertTypeConverter.ClassOrObject.OBJECT, converter.classKind)
+        }
+        alreadyGeneratedKonverterList[3].let { converter ->
+            // toClassName() would result in exception due to Resolver not initialized
+            assertEquals("List<SomeOtherTestClass>",converter.sourceType.toString())
+            assertEquals("List<SomeTestClass>",converter.targetType.toString())
+
+            assertEquals("fromSomeOtherTestClasses", converter.mapFunctionName)
+            assertEquals("source", converter.paramName)
+            assertEquals("SomeSecondTestMapper", converter.konverterInterface.simpleName)
+            assertEquals(true, converter.enabledByDefault)
+            assertEquals(999, converter.priority)
+            assertEquals(KonvertTypeConverter.ClassOrObject.CLASS, converter.classKind)
         }
     }
 
@@ -144,12 +163,46 @@ class TargetClass(val property: List<SomeOtherTestClass>)
         assertSourceEquals(
             """
             import io.mcarle.konvert.api.GeneratedKonverter
-            import io.mcarle.konvert.api.Konverter
-            import io.mcarle.konvert.processor.SomeTestMapper
+            import io.mcarle.konvert.processor.SomeTestMapperImpl
 
             @GeneratedKonverter(priority = 3_000)
             public fun SourceClass.toTargetClass(): TargetClass = TargetClass(
-              property = Konverter.get<SomeTestMapper>().toSomeOtherTestClasses(source = property)
+              property = SomeTestMapperImpl.toSomeOtherTestClasses(source = property)
+            )
+            """.trimIndent(),
+            extensionFunctionCode
+        )
+    }
+
+    @Test
+    fun useGeneratedKonverterInstanceInsteadOfIterableToIterableConverter() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(IterableToIterableConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.KonvertTo
+import io.mcarle.konvert.processor.SomeTestClass
+import io.mcarle.konvert.processor.SomeOtherTestClass
+
+@KonvertTo(TargetClass::class)
+class SourceClass(val property: List<SomeOtherTestClass>)
+class TargetClass(val property: List<SomeTestClass>)
+                """.trimIndent()
+            )
+        )
+        val extensionFunctionCode = compilation.generatedSourceFor("SourceClassKonverter.kt")
+        println(extensionFunctionCode)
+
+        assertSourceEquals(
+            """
+            import io.mcarle.konvert.api.GeneratedKonverter
+            import io.mcarle.konvert.processor.SomeSecondTestMapperImpl
+
+            @GeneratedKonverter(priority = 3_000)
+            public fun SourceClass.toTargetClass(): TargetClass = TargetClass(
+              property = SomeSecondTestMapperImpl().fromSomeOtherTestClasses(source = property)
             )
             """.trimIndent(),
             extensionFunctionCode
@@ -451,6 +504,10 @@ interface SomeTestMapper {
     fun fromSomeOtherTestClass(source: SomeOtherTestClass): SomeTestClass = SomeTestClass(source.s.toString())
 }
 
+interface SomeSecondTestMapper {
+    fun fromSomeOtherTestClasses(source: List<SomeOtherTestClass>): List<SomeTestClass>
+}
+
 /**
  * Is referenced by META-INF/konvert/io.mcarle.konvert.api.KonvertTo
  */
@@ -465,6 +522,9 @@ fun SomeOtherTestClass.Companion.fromSomeTestClass(source: SomeTestClass) = Some
     source.s.toInt()
 )
 
+/**
+ * Used to test, that a generated konverter as OBJECT can be loaded and used by Konvert
+ */
 object SomeTestMapperImpl : SomeTestMapper {
     /**
      * Is referenced by META-INF/konvert/io.mcarle.konvert.api.Konvert
@@ -488,6 +548,20 @@ object SomeTestMapperImpl : SomeTestMapper {
     @GeneratedKonverter(priority = 333)
     override fun toSomeOtherTestClasses(source: List<SomeTestClass>): List<SomeOtherTestClass> {
         return source.map { toSomeOtherTestClass(it) }
+    }
+}
+
+/**
+ * Used to test, that a generated konverter as CLASS can be loaded and used by Konvert
+ */
+class SomeSecondTestMapperImpl : SomeSecondTestMapper {
+
+    /**
+     * Is referenced by META-INF/konvert/io.mcarle.konvert.api.Konvert
+     */
+    @GeneratedKonverter(priority = 999)
+    override fun fromSomeOtherTestClasses(source: List<SomeOtherTestClass>): List<SomeTestClass> {
+        return source.map { SomeTestMapperImpl.fromSomeOtherTestClass(it) }
     }
 }
 

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToITest.kt
@@ -150,10 +150,8 @@ class TargetProperty<E>(val value: E)
 
         assertSourceEquals(
             """
-            import io.mcarle.konvert.api.Konverter
-
             public fun SourceClass.toTargetClass(): TargetClass = TargetClass(
-              targetProperty = Konverter.get<KonvertInterface>().toTargetProperty(sourceProperty = sourceProperty)
+              targetProperty = KonvertInterfaceImpl.toTargetProperty(sourceProperty = sourceProperty)
             )
         """.trimIndent(), extensionFunctionCode
         )

--- a/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.Konvert
+++ b/processor/src/test/resources/META-INF/konvert/io.mcarle.konvert.api.Konvert
@@ -2,3 +2,4 @@ thisLineShouldBeIgnoredAsNoFunctionExistsWithThisName
 io.mcarle.konvert.processor.SomeTestMapperImpl.toSomeOtherTestClass
 io.mcarle.konvert.processor.SomeTestMapperImpl.toSomeOtherTestClasses
 io.mcarle.konvert.processor.SomeTestMapperImpl.fromSomeOtherTestClass
+io.mcarle.konvert.processor.SomeSecondTestMapperImpl.fromSomeOtherTestClasses


### PR DESCRIPTION
As Konvert aims to support KMP (kotlin multiplatform), the need for reflection during runtime needed to be removed.

This commit changes the current behavior, as the generated code will *NOT* use `Konverter.get<YourMappingInterface>()` anymore for accessing `@Konverter` annotated interfaces. Instead, the generated code will directly access the generated implementation (`YourMappingInterfaceImpl`).

For compatibility, the old behavior can be configured via the option `konvert.konverter.use-reflection` with value `true`.