### PR TITLE
Pass-through `suspend` function modifier for Konverter

### DIFF
--- a/docs/annotations/konvert.adoc
+++ b/docs/annotations/konvert.adoc
@@ -6,6 +6,8 @@
 
 The annotation `@Konvert` is only being processed on abstract functions in interfaces annotated with xref:konverter.adoc[`@Konverter`].
 
+If a `@Konvert`-annotated function is a `suspend fun`, the generated counterpart is also a `suspend fun`.
+
 [source,kotlin]
 ----
 @Konverter

--- a/docs/annotations/konverter.adoc
+++ b/docs/annotations/konverter.adoc
@@ -10,6 +10,8 @@ The annotation `@Konverter` can only be applied to interfaces and will generate 
 Each abstract function which satisfies having exactly one parameter and a return type, will be implemented by generating the mapping code.
 You can define custom mappings and options per function using the xref:konvert.adoc[`@Konvert` annotation].
 
+If a function is a `suspend fun`, the generated counterpart is also a `suspend fun`.
+
 [source,kotlin]
 ----
 @Konverter

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
@@ -19,6 +19,7 @@ import io.mcarle.konvert.processor.from
 class KonvertData constructor(
     val annotationData: AnnotationData,
     val isAbstract: Boolean,
+    val isSuspend: Boolean,
     val sourceTypeReference: KSTypeReference,
     val targetTypeReference: KSTypeReference,
     val mapKSFunctionDeclaration: KSFunctionDeclaration,

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
@@ -72,6 +72,9 @@ object KonverterCodeGenerator {
                                 if (!konvertData.isAbstract) {
                                     generateSuperCall(konvertData)
                                 } else {
+                                    if (konvertData.isSuspend) {
+                                        addModifiers(KModifier.SUSPEND)
+                                    }
                                     generateMappingCode(mapper, konvertData, targetClassImportName, logger)
                                 }
                             },

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
@@ -96,6 +96,7 @@ object KonverterDataCollector {
                     KonvertData(
                         annotationData = annotation ?: KonvertData.AnnotationData.default(resolver, it.isAbstract),
                         isAbstract = it.isAbstract,
+                        isSuspend = Modifier.SUSPEND in it.modifiers,
                         sourceTypeReference = source,
                         targetTypeReference = target,
                         mapKSFunctionDeclaration = it,

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
@@ -1688,6 +1688,32 @@ interface DtoMapper {
 //            dtoMapperCode
 //        )
     }
+
+    @Test
+    fun suspendFun() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                """
+import io.mcarle.konvert.api.Konverter
+
+class SourceClass(val property: String)
+class TargetClass(val property: String)
+
+@Konverter
+interface Mapper {
+    suspend fun toTarget(source: SourceClass): TargetClass
+}
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertContains(mapperCode, "suspend fun toTarget(source: SourceClass): TargetClass")
+    }
 }
 
 private fun Konverter.Companion.getWithClassLoader(classFQN: String, classLoader: ClassLoader): Any {


### PR DESCRIPTION
Just pass through `suspend` function modifier without prejudice.