### PR TITLE
feat: support configurable mapping of non-constructor properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ All notable changes to this project will be documented in this file.
   * getter functions are now identified as sources
   * setter functions are now identified as targets
 
+### Added
+* Support for configurable mapping of non-constructor target properties:
+   * New option `konvert.non-constructor-properties-mapping` with values:
+      * `ignore` (default): only constructor parameters are mapped
+      * `auto`: all mutable properties matched by name will be mapped via `.also {}` block
+      * `strict`: only properties explicitly listed via `@Mapping(...)` are considered
+   * New option `konvert.ignore-unmapped-target-properties`:
+      * `false` (default): triggers `PropertyMappingNotExistingException` if any target property is not mapped
+      * `true`: unmapped target properties are ignored
+* Fallback mechanism: in `strict` mode, when target class has no constructor, all mutable properties are considered and a warning is logged.
+* New integration tests covering all combinations of options and edge cases
+* Updated documentation in `docs/options/index.adoc` with usage details and examples
+
 ## [4.0.1]
 
 ### Bug fixes

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/KonvertOptions.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/KonvertOptions.kt
@@ -108,3 +108,21 @@ object GENERATED_MODULE_SUFFIX_OPTION : Option<String>("konvert.generatedModuleS
  * Default: false
  */
 object PARSE_DEPRECATED_META_INF_FILES_OPTION : Option<Boolean>("konvert.parseDeprecatedMetaInfFiles", false)
+
+/**
+ * Controls how properties outside the constructor (non-constructor properties) are handled during mapping.
+ *
+ * Possible values:
+ * - "ignore" (default): Legacy behavior: if constructor parameters match all source mappings and non-constructor mapping is disabled
+ * - "auto": generates mappings for non-constructor target properties by matching source properties by name and type.
+ * - "strict": only non-constructor target properties that are explicitly declared in @Mapping will be mapped.
+ */
+object NON_CONSTRUCTOR_PROPERTIES_MAPPING_OPTION : Option<String>("konvert.non-constructor-properties-mapping", "ignore")
+
+/**
+ * If set to false (default), the processor will fail with an error if a target property is not mapped.
+ * If set to true, unmapped target properties will be silently ignored.
+ *
+ * This applies only to properties considered for mapping – depending on the current mapping mode.
+ */
+object IGNORE_UNMAPPED_TARGET_PROPERTIES_OPTION : Option<Boolean>("konvert.ignore-unmapped-target-properties", false)

--- a/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/extensions.kt
+++ b/converter-api/src/main/kotlin/io/mcarle/konvert/converter/api/config/extensions.kt
@@ -51,6 +51,18 @@ val Configuration.Companion.parseDeprecatedMetaInfFiles: Boolean
     get() = PARSE_DEPRECATED_META_INF_FILES_OPTION.get(CURRENT, String::toBoolean)
 
 /**
+ * @see NON_CONSTRUCTOR_PROPERTIES_MAPPING_OPTION
+ */
+val Configuration.Companion.nonConstructorPropertiesMapping: String
+    get() = NON_CONSTRUCTOR_PROPERTIES_MAPPING_OPTION.get(CURRENT) { it }
+
+/**
+ * @see IGNORE_UNMAPPED_TARGET_PROPERTIES_OPTION
+ */
+val Configuration.Companion.ignoreUnmappedTargetProperties: Boolean
+    get() = IGNORE_UNMAPPED_TARGET_PROPERTIES_OPTION.get(CURRENT, String::toBoolean)
+
+/**
  * Reads the value for [Option.key] from the provided `options` or fallbacks to the [Option.defaultValue].
  */
 inline fun <T> Option<T>.get(configuration: Configuration, mapping: (String) -> T): T {

--- a/docs/options/index.adoc
+++ b/docs/options/index.adoc
@@ -54,6 +54,72 @@ TIP: Have a look in the package `io.mcarle.konvert.api.config` for all provided 
 
 [cols="4,1,1,7"]
 |===
+
+a|`*konvert.non-constructor-properties-mapping*`
+a|`ignore`, `auto`, `strict`
+a|`ignore`
+a|Defines how properties of the target class that are *not* part of the constructor are handled.
+
+* `ignore` (default): only constructor parameters are considered; non-constructor properties are ignored
+* `auto`: all mutable properties not in constructor are matched by name and type automatically and mapped via `.also {}` block
+* `strict`: only properties explicitly listed via `@Mapping(...)` will be mapped; all others are ignored
+
+NOTE: If the target class has no constructor and no `@Mapping` annotations are defined,
+Konvert automatically falls back to `auto` mode and emits a warning.
+
+4+a|
+[.pl-6]
+.Example
+[%collapsible]
+====
+[source,kotlin]
+----
+class Source(val id: String) {
+    var description: String? = null
+}
+
+class Target(val id: String) {
+    var description: String? = null
+    var extra: String? = null
+}
+
+@Konverter
+interface Mapper {
+    fun map(source: Source): Target
+}
+----
+
+With configuration:
+
+[source,kotlin]
+----
+ksp {
+    arg("konvert.non-constructor-properties-mapping", "auto")
+    arg("konvert.ignore-unmapped-target-properties", "true")
+}
+----
+
+Will generate:
+
+[source,kotlin]
+----
+Target(
+  id = source.id
+).also {
+  it.description = source.description
+}
+----
+====
+
+a|`*konvert.ignore-unmapped-target-properties*`
+a|`true` / `false`
+a|`false`
+a|Defines behavior when a target property is not mapped (either automatically or via `@Mapping`).
+
+* `true`: unmapped properties are ignored
+* `false`: unmapped properties trigger `PropertyMappingNotExistingException`
+
+Note: In `strict` mode, only properties explicitly listed in `@Mapping` are considered for validation.
 |Option |Possible values |Default |Description
 
 a|`*konvert.enforce-not-null*`

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/codegen/NonConstructorPropertiesMappingITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/codegen/NonConstructorPropertiesMappingITest.kt
@@ -1,0 +1,430 @@
+package io.mcarle.konvert.processor.codegen
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.mcarle.konvert.converter.SameTypeConverter
+import io.mcarle.konvert.processor.KonverterITest
+import io.mcarle.konvert.processor.generatedSourceFor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * @author milan.machain@gmail.com
+ * @since 2025-04-08
+ */
+@Suppress("RedundantVisibilityModifier")
+@OptIn(ExperimentalCompilerApi::class)
+class NonConstructorPropertiesMappingITest : KonverterITest() {
+
+    @Test
+    fun `auto mode generates also block with matched non-constructor property`() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.OK,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "auto",
+                "konvert.ignore-unmapped-target-properties" to "true"
+            ),
+            code = SourceFile.kotlin(
+                name = "TestFooBarMapperKonverter.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konverter
+
+class Foo(val id: String) {
+    var description: String? = null
+}
+
+class Bar(val id: String) {
+    var description: String? = null
+    var extra: String? = null
+}
+
+@Konverter
+interface FooBarMapper {
+    fun map(source: Foo): Bar
+}
+                    """.trimIndent()
+            )
+        )
+
+        val generated = compilation.generatedSourceFor("FooBarMapperKonverter.kt")
+
+        assertSourceEquals(
+            """
+            public object FooBarMapperImpl : FooBarMapper {
+              override fun map(source: Foo): Bar = Bar(
+                id = source.id
+              ).also { bar ->
+                bar.description = source.description
+              }
+            }
+            """.trimIndent(),
+            generated
+        )
+    }
+
+    @Test
+    fun `strict mode passes if only constructor parameters are present and matched`() {
+        val (compilation, compilationResult) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.OK,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "strict",
+                "konvert.ignore-unmapped-target-properties" to "false"
+            ),
+            code = SourceFile.kotlin(
+                name = "StrictConstructorOnly.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konverter
+
+class Foo(val id: String)
+
+class Bar(val id: String)
+
+@Konverter
+interface ConstructorOnlyMapper {
+    fun map(source: Foo): Bar
+}
+                """.trimIndent()
+            )
+        )
+
+        val generated = compilation.generatedSourceFor("ConstructorOnlyMapperKonverter.kt")
+
+        assertTrue("id = source.id" in generated)
+        assertFalse("also" in generated)
+    }
+
+    @Test
+    fun `strict mode maps only explicitly listed non-constructor property`() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.OK,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "strict",
+                "konvert.ignore-unmapped-target-properties" to "true"
+            ),
+            code = SourceFile.kotlin(
+                name = "StrictExplicit.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konfig
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Mapping
+
+class Foo(val id: String) {
+    var description: String? = null
+}
+
+class Bar(val id: String) {
+    var description: String? = null
+    var extra: String? = null
+}
+
+@Konverter(
+    options = [
+        Konfig("konvert.non-constructor-properties-mapping", "strict"),
+        Konfig("konvert.ignore-unmapped-target-properties", "true")
+    ]
+)
+interface StrictExplicitMapper {
+    @Konvert(
+        mappings = [Mapping(target = "description", source = "description")]
+    )
+    fun map(source: Foo): Bar
+}
+                """.trimIndent()
+            )
+        )
+
+        val generated = compilation.generatedSourceFor("StrictExplicitMapperKonverter.kt")
+
+        assertTrue("description = source.description" in generated)
+        assertFalse("extra =" in generated) // unmapped, but ignored
+    }
+
+    @Test
+    fun `strict mode with no constructor and no mappings uses fallback`() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.OK,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "strict",
+                "konvert.ignore-unmapped-target-properties" to "true"
+            ),
+            code = SourceFile.kotlin(
+                name = "StrictFallback.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konverter
+
+class Foo(val id: String) {
+    var description: String? = null
+}
+
+class Bar {
+    var description: String? = null
+    var extra: String? = null
+}
+
+@Konverter
+interface FallbackMapper {
+    fun map(source: Foo): Bar
+}
+                """.trimIndent()
+            )
+        )
+
+        val generated = compilation.generatedSourceFor("FallbackMapperKonverter.kt")
+
+        assertTrue("also" in generated)
+        assertTrue("description = source.description" in generated)
+        assertFalse("extra =" in generated)
+    }
+
+    @Test
+    fun `strict mode respects @Mapping on constructor property`() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.OK,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "strict",
+                "konvert.ignore-unmapped-target-properties" to "true"
+            ),
+            code = SourceFile.kotlin(
+                name = "StrictMappingOnConstructor.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Mapping
+
+class Foo(val identifier: String)
+
+class Bar(val id: String)
+
+@Konverter
+interface ConstructorMappedMapper {
+    @Konvert(mappings = [Mapping(target = "id", source = "identifier")])
+    fun map(source: Foo): Bar
+}
+                """.trimIndent()
+            )
+        )
+
+        val generated = compilation.generatedSourceFor("ConstructorMappedMapperKonverter.kt")
+
+        assertTrue("id = source.identifier" in generated)
+        assertFalse("also" in generated)
+    }
+
+
+    @Test
+    fun `auto mode fails if unmapped and ignore-unmapped=false`() {
+        val (_, compilationResult) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "auto",
+                "konvert.ignore-unmapped-target-properties" to "false"
+            ),
+            code = SourceFile.kotlin(
+                name = "AutoFails.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konverter
+
+class Foo(val id: String)
+
+class Bar(val id: String) {
+    var extra: String? = null
+}
+
+@Konverter
+interface AutoFailsMapper {
+    fun map(source: Foo): Bar
+}
+                """.trimIndent()
+            )
+        )
+
+        assertTrue(
+            compilationResult.messages.contains("PropertyMappingNotExistingException"),
+            "Expected failure due to unmapped 'extra' property:\n${compilationResult.messages}"
+        )
+    }
+
+
+    @Test
+    fun `ignore mode with Mapping on constructor property does not trigger fallback`() {
+        val (compilation, _) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.OK,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "ignore",
+                "konvert.ignore-unmapped-target-properties" to "true"
+            ),
+            code = SourceFile.kotlin(
+                name = "IgnoreWithConstructorMapping.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Mapping
+
+class Foo(val identifier: String)
+
+class Bar(val id: String) {
+    var extra: String? = null
+}
+
+@Konverter
+interface IgnoreCtorMapper {
+    @Konvert(mappings = [Mapping(target = "id", source = "identifier")])
+    fun map(source: Foo): Bar
+}
+                """.trimIndent()
+            )
+        )
+
+        val generated = compilation.generatedSourceFor("IgnoreCtorMapperKonverter.kt")
+
+        assertTrue("id = source.identifier" in generated)
+        assertFalse("also" in generated)
+    }
+
+
+    @Test
+    fun `ignore mode with Mapping on non-constructor property triggers fallback`() {
+        val (compilation, _) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.OK,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "ignore",
+                "konvert.ignore-unmapped-target-properties" to "true"
+            ),
+            code = SourceFile.kotlin(
+                name = "IgnoreFallback.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Mapping
+
+class Foo(val id: String) {
+    var description: String? = null
+}
+
+class Bar(val id: String) {
+    var description: String? = null
+}
+
+@Konverter
+interface IgnoreTriggersAlsoMapper {
+    @Konvert(mappings = [Mapping(target = "description", source = "description")])
+    fun map(source: Foo): Bar
+}
+                """.trimIndent()
+            )
+        )
+
+        val generated = compilation.generatedSourceFor("IgnoreTriggersAlsoMapperKonverter.kt")
+
+        assertTrue("description = source.description" in generated)
+        assertTrue("also" in generated)
+    }
+
+    @Test
+    fun `strict mode fails if explicit mapping source does not exist`() {
+        val (_, compilationResult) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "strict",
+                "konvert.ignore-unmapped-target-properties" to "false"
+            ),
+            code = SourceFile.kotlin(
+                name = "StrictFailsMissingSource.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Mapping
+
+class Foo(val id: String)
+
+class Bar(val id: String) {
+    var missingSource: String? = null
+}
+
+@Konverter
+interface StrictMissingSourceMapper {
+    @Konvert(mappings = [
+        Mapping(target = "missingSource", source = "notExistingProperty")
+    ])
+    fun map(source: Foo): Bar
+}
+                """.trimIndent()
+            )
+        )
+
+        assertTrue(
+            compilationResult.messages.contains("PropertyMappingNotExistingException"),
+            "Expected failure due to missing source property:\n${compilationResult.messages}"
+        )
+    }
+
+    @Test
+    fun `strict mode maps only explicitly listed non-constructor property when multiple exist`() {
+        val (compilation, _) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.OK,
+            options = mapOf(
+                "konvert.non-constructor-properties-mapping" to "strict",
+                "konvert.ignore-unmapped-target-properties" to "true"
+            ),
+            code = SourceFile.kotlin(
+                name = "StrictMultipleNonConstructorProperties.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Mapping
+
+class Foo(val id: String) {
+    var description: String? = null
+    var note: String? = null
+}
+
+class Bar(val id: String) {
+    var description: String? = null
+    var note: String? = null
+    var extra: String? = null
+}
+
+@Konverter
+interface StrictMultiplePropertiesMapper {
+    @Konvert(
+        mappings = [
+            Mapping(target = "description", source = "description")
+        ]
+    )
+    fun map(source: Foo): Bar
+}
+                """.trimIndent()
+            )
+        )
+
+        val generated = compilation.generatedSourceFor("StrictMultiplePropertiesMapperKonverter.kt")
+
+        assertTrue("description = source.description" in generated)
+        assertFalse("note =" in generated)
+        assertFalse("extra =" in generated)
+    }
+
+}


### PR DESCRIPTION
### Summary

This PR introduces configurable behavior for mapping target properties outside the constructor.

### Motivation

Currently, non-constructor properties are ignored unless at least one is listed via `@Mapping`, which implicitly triggers `.also {}` block generation. This behavior leads to unnecessary boilerplate and unintuitive side effects.

Example of current workaround:

```kotlin
@Konverter
fun interface ProjectKonverter {
    @Konvert(mappings = [Mapping(target = "title", source = "title")]) // non-constructor fields hack
    fun map(source: Project): ProjectRE
}

@Konverter
fun interface ProjectModelKonverter {
    @Konvert(mappings = [Mapping(target = "description", source = "description")]) // non-constructor fields hack
    fun map(source: ProjectModel): ProjectModelRE
}
```
Each of these classes has a constructor, but the goal is to map *all* relevant properties, including those outside the constructor – without hacks.

### Features

- `konvert.non-constructor-properties-mapping = ignore | auto | strict`
- `konvert.ignore-unmapped-target-properties = true | false`
- fallback to `auto` if no constructor and no mappings exist (with warning)
- integration tests covering all modes and edge cases
- documentation update: `index.adoc`

### Related issue

Closes https://github.com/mcarleio/konvert/issues/124
