### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mcarleio/konvert/security/code-scanning/1](https://github.com/mcarleio/konvert/security/code-scanning/1)

To fix this problem, you should add a `permissions` block to the workflow to specify the minimum required privileges for the `GITHUB_TOKEN`. Ideally, this should be placed at the workflow root (at the same level as `name`/`on`/`jobs`) so all jobs inherit the setting, unless some jobs require different permissions. For most build and test workflows where the `GITHUB_TOKEN` is only used by some steps (e.g., uploading to Codecov, fetching private repo dependencies, etc.) and it's not used for writing resources, the most restrictive practical setting is `contents: read`. If any step requires broader access, add only those additional scopes (e.g., `pull-requests: write`). In this case, a `permissions` block with only `contents: read` at the root is safest and should not break any functionality.

You should insert the following block after the workflow `name` and before the `on` section:

```yaml
permissions:
  contents: read
```

No other code, steps, or keys should be modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
