### PR TITLE
Make KSP processor work in commonMain metadata compilation

### DIFF
--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/BaseTypeConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/BaseTypeConverter.kt
@@ -17,14 +17,21 @@ abstract class BaseTypeConverter(
     override val enabledByDefault: Boolean = false
 ) : AbstractTypeConverter() {
 
-    private val sourceType: KSType by lazy {
-        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)!!.asStarProjectedType()
+    // Nullable: in non-JVM KSP compilations (e.g. kspCommonMainKotlinMetadata or native targets)
+    // a converter may reference a type that is not on the current classpath — most notably the
+    // java.* types used by the BigInteger/BigDecimal/Date converters. In that case the class
+    // declaration cannot be resolved; such a converter simply can never match in this compilation,
+    // so we treat an unresolvable type as "no match" instead of throwing an NPE.
+    private val sourceType: KSType? by lazy {
+        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)?.asStarProjectedType()
     }
-    private val targetType: KSType by lazy {
-        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)!!.asStarProjectedType()
+    private val targetType: KSType? by lazy {
+        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val sourceType = sourceType ?: return false
+        val targetType = targetType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             sourceNotNullable == sourceType && targetNotNullable == targetType
         }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToTemporalConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToTemporalConverter.kt
@@ -15,15 +15,17 @@ abstract class DateToTemporalConverter(
     val targetClass: KClass<out Temporal>
 ) : AbstractTypeConverter() {
 
-    private val dateType: KSType by lazy {
-        resolver.getClassDeclarationByName("java.util.Date")!!.asStarProjectedType()
+    private val dateType: KSType? by lazy {
+        resolver.getClassDeclarationByName("java.util.Date")?.asStarProjectedType()
     }
 
-    private val targetType: KSType by lazy {
-        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)!!.asStarProjectedType()
+    private val targetType: KSType? by lazy {
+        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val dateType = dateType ?: return false
+        val targetType = targetType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             dateType.isAssignableFrom(sourceNotNullable) && targetType == targetNotNullable
         }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToXConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/DateToXConverter.kt
@@ -15,15 +15,17 @@ abstract class DateToXConverter(
     val targetClass: KClass<*>
 ) : AbstractTypeConverter() {
 
-    private val dateType: KSType by lazy {
-        resolver.getClassDeclarationByName("java.util.Date")!!.asStarProjectedType()
+    private val dateType: KSType? by lazy {
+        resolver.getClassDeclarationByName("java.util.Date")?.asStarProjectedType()
     }
 
-    private val targetType: KSType by lazy {
-        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)!!.asStarProjectedType()
+    private val targetType: KSType? by lazy {
+        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val dateType = dateType ?: return false
+        val targetType = targetType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             dateType.isAssignableFrom(sourceNotNullable) && targetType == targetNotNullable
         }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/EnumToXConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/EnumToXConverter.kt
@@ -15,15 +15,17 @@ abstract class EnumToXConverter(
     val targetClass: KClass<*>
 ) : AbstractTypeConverter() {
 
-    private val enumType: KSType by lazy {
-        resolver.getClassDeclarationByName<Enum<*>>()!!.asStarProjectedType()
+    private val enumType: KSType? by lazy {
+        resolver.getClassDeclarationByName<Enum<*>>()?.asStarProjectedType()
     }
 
-    private val targetType: KSType by lazy {
-        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)!!.asStarProjectedType()
+    private val targetType: KSType? by lazy {
+        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val enumType = enumType ?: return false
+        val targetType = targetType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             enumType.isAssignableFrom(sourceNotNullable) && targetType == targetNotNullable
         }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToDateConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToDateConverter.kt
@@ -17,15 +17,17 @@ abstract class TemporalToDateConverter(
     val sourceClass: KClass<out Temporal>,
 ) : AbstractTypeConverter() {
 
-    private val temporalType: KSType by lazy {
-        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)!!.asStarProjectedType()
+    private val temporalType: KSType? by lazy {
+        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)?.asStarProjectedType()
     }
 
-    private val targetType: KSType by lazy {
-        resolver.getClassDeclarationByName("java.util.Date")!!.asStarProjectedType()
+    private val targetType: KSType? by lazy {
+        resolver.getClassDeclarationByName("java.util.Date")?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val temporalType = temporalType ?: return false
+        val targetType = targetType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             temporalType.isAssignableFrom(sourceNotNullable) && targetType == targetNotNullable
         }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToTemporalConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToTemporalConverter.kt
@@ -22,15 +22,17 @@ abstract class TemporalToTemporalConverter(
     val targetClass: KClass<out Temporal>,
 ) : AbstractTypeConverter() {
 
-    private val sourceType: KSType by lazy {
-        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)!!.asStarProjectedType()
+    private val sourceType: KSType? by lazy {
+        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)?.asStarProjectedType()
     }
 
-    private val targetType: KSType by lazy {
-        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)!!.asStarProjectedType()
+    private val targetType: KSType? by lazy {
+        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val sourceType = sourceType ?: return false
+        val targetType = targetType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             sourceType.isAssignableFrom(sourceNotNullable) && targetType == targetNotNullable
         }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToXConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/TemporalToXConverter.kt
@@ -24,15 +24,17 @@ abstract class TemporalToXConverter(
     val targetClass: KClass<*>,
 ) : AbstractTypeConverter() {
 
-    private val temporalType: KSType by lazy {
-        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)!!.asStarProjectedType()
+    private val temporalType: KSType? by lazy {
+        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)?.asStarProjectedType()
     }
 
-    private val targetType: KSType by lazy {
-        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)!!.asStarProjectedType()
+    private val targetType: KSType? by lazy {
+        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val temporalType = temporalType ?: return false
+        val targetType = targetType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             temporalType.isAssignableFrom(sourceNotNullable) && targetType == targetNotNullable
         }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/XToDateConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/XToDateConverter.kt
@@ -15,15 +15,17 @@ abstract class XToDateConverter(
     val sourceClass: KClass<*>
 ) : AbstractTypeConverter() {
 
-    private val dateType: KSType by lazy {
-        resolver.getClassDeclarationByName("java.util.Date")!!.asStarProjectedType()
+    private val dateType: KSType? by lazy {
+        resolver.getClassDeclarationByName("java.util.Date")?.asStarProjectedType()
     }
 
-    private val sourceType: KSType by lazy {
-        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)!!.asStarProjectedType()
+    private val sourceType: KSType? by lazy {
+        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val dateType = dateType ?: return false
+        val sourceType = sourceType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             sourceType == sourceNotNullable && dateType == targetNotNullable
         }

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/XToEnumConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/XToEnumConverter.kt
@@ -15,15 +15,17 @@ abstract class XToEnumConverter(
     val sourceClass: KClass<*>
 ) : AbstractTypeConverter() {
 
-    private val enumType: KSType by lazy {
-        resolver.getClassDeclarationByName<Enum<*>>()!!.asStarProjectedType()
+    private val enumType: KSType? by lazy {
+        resolver.getClassDeclarationByName<Enum<*>>()?.asStarProjectedType()
     }
 
-    private val sourceType: KSType by lazy {
-        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)!!.asStarProjectedType()
+    private val sourceType: KSType? by lazy {
+        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val enumType = enumType ?: return false
+        val sourceType = sourceType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             enumType != targetNotNullable && enumType.isAssignableFrom(targetNotNullable)
                 && sourceType == sourceNotNullable

--- a/converter/src/main/kotlin/io/mcarle/konvert/converter/XToTemporalConverter.kt
+++ b/converter/src/main/kotlin/io/mcarle/konvert/converter/XToTemporalConverter.kt
@@ -24,15 +24,17 @@ abstract class XToTemporalConverter(
     val targetClass: KClass<out Temporal>,
 ) : AbstractTypeConverter() {
 
-    private val temporalType: KSType by lazy {
-        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)!!.asStarProjectedType()
+    private val temporalType: KSType? by lazy {
+        resolver.getClassDeclarationByName(targetClass.qualifiedName!!)?.asStarProjectedType()
     }
 
-    private val sourceType: KSType by lazy {
-        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)!!.asStarProjectedType()
+    private val sourceType: KSType? by lazy {
+        resolver.getClassDeclarationByName(sourceClass.qualifiedName!!)?.asStarProjectedType()
     }
 
     override fun matches(source: KSType, target: KSType): Boolean {
+        val temporalType = temporalType ?: return false
+        val sourceType = sourceType ?: return false
         return handleNullable(source, target) { sourceNotNullable, targetNotNullable ->
             sourceType == sourceNotNullable && temporalType == targetNotNullable
         }

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/extensions.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/extensions.kt
@@ -1,9 +1,12 @@
 package io.mcarle.konvert.processor
 
+import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.symbol.Visibility
 import io.mcarle.konvert.api.Konfig
@@ -47,20 +50,62 @@ fun Iterable<Mapping>.validated(reference: KSNode, logger: KSPLogger) = filter {
     }
 }
 
+/**
+ * Resolves the value of an annotation argument by [name].
+ *
+ * On platform KSP compilations every argument (including ones left at their default) is
+ * materialized in [KSAnnotation.arguments]. In the common-metadata compilation
+ * (`kspCommonMainKotlinMetadata`) KSP may omit arguments that were not explicitly set —
+ * and [KSAnnotation.defaultArguments] is likewise unreliable there (array-valued defaults
+ * such as `mappings = []` come back as `null`). A naive
+ * `arguments.first { it.name == name }.value` therefore throws [NoSuchElementException], and
+ * even after guarding the lookup the value may be `null`.
+ *
+ * We resolve in priority order: explicit argument → KSP default argument → [fallback].
+ */
+fun KSAnnotation.argumentValue(name: String, fallback: Any? = null): Any? {
+    arguments.firstOrNull { it.name?.asString() == name }?.let { if (it.value != null) return it.value }
+    defaultArguments.firstOrNull { it.name?.asString() == name }?.let { if (it.value != null) return it.value }
+    return fallback
+}
+
+/**
+ * Resolves the `constructorArgs` annotation value into [KSClassDeclaration]s.
+ *
+ * Two states must be distinguished, which is impossible from the value alone in the
+ * common-metadata compilation (where a defaulted argument is dropped from
+ * [KSAnnotation.arguments]):
+ *  - **absent** (left at its `[Unit::class]` default) → the "auto-detect constructor" sentinel.
+ *    We synthesize `[Unit]` so downstream behaves exactly as in a platform compilation.
+ *  - **explicitly empty** (`constructorArgs = []`) → "use the empty/no-arg constructor".
+ *    We must preserve the empty list.
+ *
+ * We treat the argument as explicitly set only when it appears in [KSAnnotation.arguments]
+ * with a non-null value; otherwise we fall back to the [Unit] sentinel.
+ */
+fun KSAnnotation.constructorArgClassDeclarations(name: String, resolver: Resolver): List<KSClassDeclaration> {
+    val explicit = arguments.firstOrNull { it.name?.asString() == name }?.value
+    if (explicit != null) {
+        return (explicit as List<*>).mapNotNull { (it as? KSType)?.classDeclaration() }
+    }
+    val unit = resolver.getClassDeclarationByName(Unit::class.qualifiedName!!)
+    return listOfNotNull(unit)
+}
+
 fun Mapping.Companion.from(annotation: KSAnnotation) = Mapping(
-    target = annotation.arguments.first { it.name?.asString() == Mapping::target.name }.value as String,
-    source = annotation.arguments.first { it.name?.asString() == Mapping::source.name }.value as String,
-    constant = annotation.arguments.first { it.name?.asString() == Mapping::constant.name }.value as String,
-    expression = annotation.arguments.first { it.name?.asString() == Mapping::expression.name }.value as String,
-    ignore = annotation.arguments.first { it.name?.asString() == Mapping::ignore.name }.value as Boolean,
-    enable = (annotation.arguments.first { it.name?.asString() == Mapping::enable.name }.value as List<*>)
+    target = annotation.argumentValue(Mapping::target.name) as String,
+    source = annotation.argumentValue(Mapping::source.name, "") as String,
+    constant = annotation.argumentValue(Mapping::constant.name, "") as String,
+    expression = annotation.argumentValue(Mapping::expression.name, "") as String,
+    ignore = annotation.argumentValue(Mapping::ignore.name, false) as Boolean,
+    enable = (annotation.argumentValue(Mapping::enable.name, emptyList<Any?>()) as List<*>)
         .filterIsInstance<TypeConverterName>()
         .toTypedArray(),
 )
 
 fun Konfig.Companion.from(annotation: KSAnnotation) = Konfig(
-    key = annotation.arguments.first { it.name?.asString() == Konfig::key.name }.value as String,
-    value = annotation.arguments.first { it.name?.asString() == Konfig::value.name }.value as String
+    key = annotation.argumentValue(Konfig::key.name) as String,
+    value = annotation.argumentValue(Konfig::value.name) as String
 )
 
 fun KSValueParameter.typeClassDeclaration(): KSClassDeclaration? = this.type.resolve().classDeclaration()

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/extensions.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/extensions.kt
@@ -62,6 +62,12 @@ fun Iterable<Mapping>.validated(reference: KSNode, logger: KSPLogger) = filter {
  * even after guarding the lookup the value may be `null`.
  *
  * We resolve in priority order: explicit argument → KSP default argument → [fallback].
+ *
+ * Note on testing: the metadata-phase behavior this guards against cannot be reproduced in
+ * the `*ITest` harness, which runs a JVM platform compilation via kotlin-compile-testing
+ * (no commonMain-metadata KSP mode exists there). This function is therefore unit-tested
+ * directly against a fake [KSAnnotation] simulating the metadata phase — see
+ * `AnnotationArgumentExtensionsTest`.
  */
 fun KSAnnotation.argumentValue(name: String, fallback: Any? = null): Any? {
     arguments.firstOrNull { it.name?.asString() == name }?.let { if (it.value != null) return it.value }
@@ -82,6 +88,13 @@ fun KSAnnotation.argumentValue(name: String, fallback: Any? = null): Any? {
  *
  * We treat the argument as explicitly set only when it appears in [KSAnnotation.arguments]
  * with a non-null value; otherwise we fall back to the [Unit] sentinel.
+ *
+ * Note on testing: the absent-vs-explicit-empty distinction only diverges in the
+ * common-metadata compilation. In the JVM `*ITest` harness a defaulted `constructorArgs`
+ * always arrives as `[Unit::class]`, so those integration tests exercise the unchanged
+ * platform path and cannot prove this fix. Faithful coverage would require running
+ * `kspCommonMainKotlinMetadata` (and, for native consumers, macOS runners with the
+ * Kotlin/Native toolchain), neither of which is available to the integration harness.
  */
 fun KSAnnotation.constructorArgClassDeclarations(name: String, resolver: Resolver): List<KSClassDeclaration> {
     val explicit = arguments.firstOrNull { it.name?.asString() == name }?.value

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
@@ -9,11 +9,14 @@ import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSValueParameter
 import io.mcarle.konvert.api.DEFAULT_KONVERTER_PRIORITY
+import io.mcarle.konvert.api.DEFAULT_KONVERT_PRIORITY
 import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.Konvert
 import io.mcarle.konvert.api.Mapping
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.classDeclaration
+import io.mcarle.konvert.processor.argumentValue
+import io.mcarle.konvert.processor.constructorArgClassDeclarations
 import io.mcarle.konvert.processor.from
 
 class KonvertData constructor(
@@ -43,13 +46,13 @@ class KonvertData constructor(
     ) {
 
         companion object {
-            fun from(annotation: KSAnnotation) = AnnotationData(
-                mappings = (annotation.arguments.first { it.name?.asString() == Konvert::mappings.name }.value as List<*>)
+            fun from(annotation: KSAnnotation, resolver: Resolver) = AnnotationData(
+                mappings = (annotation.argumentValue(Konvert::mappings.name, emptyList<Any?>()) as List<*>)
                     .filterIsInstance<KSAnnotation>()
                     .map { Mapping.from(it) },
-                constructor = (annotation.arguments.first { it.name?.asString() == Konvert::constructorArgs.name }.value as List<*>).mapNotNull { (it as? KSType)?.classDeclaration() },
-                priority = annotation.arguments.first { it.name?.asString() == Konvert::priority.name }.value as Priority,
-                options = (annotation.arguments.first { it.name?.asString() == Konvert::options.name }.value as List<*>)
+                constructor = annotation.constructorArgClassDeclarations(Konvert::constructorArgs.name, resolver),
+                priority = annotation.argumentValue(Konvert::priority.name, DEFAULT_KONVERT_PRIORITY) as Priority,
+                options = (annotation.argumentValue(Konvert::options.name, emptyList<Any?>()) as List<*>)
                     .filterIsInstance<KSAnnotation>()
                     .map { Konfig.from(it) },
             )

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterData.kt
@@ -8,6 +8,7 @@ import io.mcarle.konvert.converter.api.config.konverterGenerateClass
 import io.mcarle.konvert.converter.api.config.withIsolatedConfiguration
 import io.mcarle.konvert.processor.AnnotatedConverter
 import io.mcarle.konvert.processor.AnnotatedConverterData
+import io.mcarle.konvert.processor.argumentValue
 import io.mcarle.konvert.processor.from
 
 class KonverterData constructor(
@@ -42,7 +43,7 @@ class KonverterData constructor(
 
         companion object {
             fun from(annotation: KSAnnotation) = AnnotationData(
-                options = (annotation.arguments.first { it.name?.asString() == Konverter::options.name }.value as List<*>)
+                options = (annotation.argumentValue(Konverter::options.name, emptyList<Any?>()) as List<*>)
                     .filterIsInstance<KSAnnotation>()
                     .map { Konfig.from(it) },
             )

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
@@ -75,7 +75,7 @@ object KonverterDataCollector {
                 }?.let { annotation ->
                     // cannot use getAnnotationsByType, as the Konvert.constructor classes may be part of this compilation and
                     // therefore results in ClassNotFoundExceptions when accessing it
-                    KonvertData.AnnotationData.from(annotation)
+                    KonvertData.AnnotationData.from(annotation, resolver)
                 }
 
                 if (it.isAbstract) {

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromData.kt
@@ -3,13 +3,17 @@ package io.mcarle.konvert.processor.konvertfrom
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
+import io.mcarle.konvert.api.DEFAULT_KONVERT_FROM_PRIORITY
 import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.KonvertFrom
 import io.mcarle.konvert.api.Mapping
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.classDeclaration
+import com.google.devtools.ksp.processing.Resolver
 import io.mcarle.konvert.processor.AnnotatedConverter
 import io.mcarle.konvert.processor.AnnotatedConverterData
+import io.mcarle.konvert.processor.argumentValue
+import io.mcarle.konvert.processor.constructorArgClassDeclarations
 import io.mcarle.konvert.processor.from
 import java.util.Locale
 
@@ -48,15 +52,15 @@ class KonvertFromData(
     ) {
 
         companion object {
-            fun from(annotation: KSAnnotation) = AnnotationData(
-                value = (annotation.arguments.first { it.name?.asString() == KonvertFrom::value.name }.value as KSType).classDeclaration()!!,
-                mappings = (annotation.arguments.first { it.name?.asString() == KonvertFrom::mappings.name }.value as List<*>)
+            fun from(annotation: KSAnnotation, resolver: Resolver) = AnnotationData(
+                value = (annotation.argumentValue(KonvertFrom::value.name) as KSType).classDeclaration()!!,
+                mappings = (annotation.argumentValue(KonvertFrom::mappings.name, emptyList<Any?>()) as List<*>)
                     .filterIsInstance<KSAnnotation>()
                     .map { Mapping.from(it) },
-                constructor = (annotation.arguments.first { it.name?.asString() == KonvertFrom::constructorArgs.name }.value as List<*>).mapNotNull { (it as? KSType)?.classDeclaration() },
-                mapFunctionName = annotation.arguments.first { it.name?.asString() == KonvertFrom::mapFunctionName.name }.value as String,
-                priority = annotation.arguments.first { it.name?.asString() == KonvertFrom::priority.name }.value as Priority,
-                options = (annotation.arguments.first { it.name?.asString() == KonvertFrom::options.name }.value as List<*>)
+                constructor = annotation.constructorArgClassDeclarations(KonvertFrom::constructorArgs.name, resolver),
+                mapFunctionName = annotation.argumentValue(KonvertFrom::mapFunctionName.name, "") as String,
+                priority = annotation.argumentValue(KonvertFrom::priority.name, DEFAULT_KONVERT_FROM_PRIORITY) as Priority,
+                options = (annotation.argumentValue(KonvertFrom::options.name, emptyList<Any?>()) as List<*>)
                     .filterIsInstance<KSAnnotation>()
                     .map { Konfig.from(it) },
             )

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromDataCollector.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertfrom/KonvertFromDataCollector.kt
@@ -27,7 +27,7 @@ object KonvertFromDataCollector {
                     .map {
                         // cannot use getAnnotationsByType, as the KonvertFrom.value class may be part of this compilation and
                         // therefore results in ClassNotFoundExceptions when accessing it
-                        KonvertFromData.AnnotationData.from(it)
+                        KonvertFromData.AnnotationData.from(it, resolver)
                     }
                     .map {
                         KonvertFromData(

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToData.kt
@@ -4,13 +4,17 @@ import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.squareup.kotlinpoet.ksp.toClassName
+import io.mcarle.konvert.api.DEFAULT_KONVERT_TO_PRIORITY
 import io.mcarle.konvert.api.Konfig
 import io.mcarle.konvert.api.KonvertTo
 import io.mcarle.konvert.api.Mapping
 import io.mcarle.konvert.api.Priority
 import io.mcarle.konvert.converter.api.classDeclaration
+import com.google.devtools.ksp.processing.Resolver
 import io.mcarle.konvert.processor.AnnotatedConverter
 import io.mcarle.konvert.processor.AnnotatedConverterData
+import io.mcarle.konvert.processor.argumentValue
+import io.mcarle.konvert.processor.constructorArgClassDeclarations
 import io.mcarle.konvert.processor.from
 
 class KonvertToData(
@@ -45,15 +49,15 @@ class KonvertToData(
     ) {
 
         companion object {
-            fun from(annotation: KSAnnotation) = AnnotationData(
-                value = (annotation.arguments.first { it.name?.asString() == KonvertTo::value.name }.value as KSType).classDeclaration()!!,
-                mappings = (annotation.arguments.first { it.name?.asString() == KonvertTo::mappings.name }.value as List<*>)
+            fun from(annotation: KSAnnotation, resolver: Resolver) = AnnotationData(
+                value = (annotation.argumentValue(KonvertTo::value.name) as KSType).classDeclaration()!!,
+                mappings = (annotation.argumentValue(KonvertTo::mappings.name, emptyList<Any?>()) as List<*>)
                     .filterIsInstance<KSAnnotation>()
                     .map { Mapping.from(it) },
-                constructor = (annotation.arguments.first { it.name?.asString() == KonvertTo::constructorArgs.name }.value as List<*>).mapNotNull { (it as? KSType)?.classDeclaration() },
-                mapFunctionName = annotation.arguments.first { it.name?.asString() == KonvertTo::mapFunctionName.name }.value as String,
-                priority = annotation.arguments.first { it.name?.asString() == KonvertTo::priority.name }.value as Priority,
-                options = (annotation.arguments.first { it.name?.asString() == KonvertTo::options.name }.value as List<*>)
+                constructor = annotation.constructorArgClassDeclarations(KonvertTo::constructorArgs.name, resolver),
+                mapFunctionName = annotation.argumentValue(KonvertTo::mapFunctionName.name, "") as String,
+                priority = annotation.argumentValue(KonvertTo::priority.name, DEFAULT_KONVERT_TO_PRIORITY) as Priority,
+                options = (annotation.argumentValue(KonvertTo::options.name, emptyList<Any?>()) as List<*>)
                     .filterIsInstance<KSAnnotation>()
                     .map { Konfig.from(it) },
             )

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToDataCollector.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvertto/KonvertToDataCollector.kt
@@ -26,7 +26,7 @@ object KonvertToDataCollector {
                     .map {
                         // cannot use getAnnotationsByType, as the KonvertTo.value class may be part of this compilation and
                         // therefore results in ClassNotFoundExceptions when accessing it
-                        KonvertToData.AnnotationData.from(it)
+                        KonvertToData.AnnotationData.from(it, resolver)
                     }
                     .map {
                         KonvertToData(

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/AnnotationArgumentExtensionsTest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/AnnotationArgumentExtensionsTest.kt
@@ -1,0 +1,125 @@
+package io.mcarle.konvert.processor
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSValueArgument
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * Unit tests for [argumentValue].
+ *
+ * These reproduce the `kspCommonMainKotlinMetadata` (common-metadata) behavior that the JVM
+ * `*ITest` integration harness cannot: in that phase KSP omits defaulted arguments from
+ * [KSAnnotation.arguments] and returns `null` values for array-typed entries in
+ * [KSAnnotation.defaultArguments]. We fake [KSAnnotation] to simulate exactly that and assert
+ * the helper resolves robustly instead of throwing [NoSuchElementException] / casting `null`.
+ */
+class AnnotationArgumentExtensionsTest {
+
+    @Test
+    fun returnsExplicitArgumentValueWhenPresent() {
+        val annotation = fakeAnnotation(
+            arguments = listOf("target" to "Foo"),
+            defaultArguments = emptyList()
+        )
+
+        assertEquals("Foo", annotation.argumentValue("target", fallback = "fallback"))
+    }
+
+    @Test
+    fun fallsBackToDefaultArgumentWhenNotExplicitlySet() {
+        val annotation = fakeAnnotation(
+            arguments = emptyList(),
+            defaultArguments = listOf("priority" to 42)
+        )
+
+        assertEquals(42, annotation.argumentValue("priority", fallback = -1))
+    }
+
+    @Test
+    fun usesCallerFallbackWhenArgumentIsAbsentEntirely() {
+        // Simulates a defaulted argument that the metadata phase drops from both lists.
+        val annotation = fakeAnnotation(
+            arguments = emptyList(),
+            defaultArguments = emptyList()
+        )
+
+        assertEquals("", annotation.argumentValue("source", fallback = ""))
+    }
+
+    @Test
+    fun usesCallerFallbackWhenArrayDefaultComesBackNull() {
+        // In the metadata phase array-valued defaults (e.g. `mappings = []`) materialize with a
+        // null value; the helper must not return that null (which would NPE on `as List<*>`).
+        val fallback = emptyList<Any?>()
+        val annotation = fakeAnnotation(
+            arguments = emptyList(),
+            defaultArguments = listOf("mappings" to null)
+        )
+
+        assertSame(fallback, annotation.argumentValue("mappings", fallback = fallback))
+    }
+
+    @Test
+    fun prefersExplicitArgumentOverDefault() {
+        val annotation = fakeAnnotation(
+            arguments = listOf("priority" to 7),
+            defaultArguments = listOf("priority" to 42)
+        )
+
+        assertEquals(7, annotation.argumentValue("priority", fallback = -1))
+    }
+
+    @Test
+    fun ignoresExplicitNullValueAndFallsThrough() {
+        val annotation = fakeAnnotation(
+            arguments = listOf("priority" to null),
+            defaultArguments = listOf("priority" to 42)
+        )
+
+        assertEquals(42, annotation.argumentValue("priority", fallback = -1))
+    }
+
+    private fun fakeAnnotation(
+        arguments: List<Pair<String, Any?>>,
+        defaultArguments: List<Pair<String, Any?>>
+    ): KSAnnotation {
+        val args = arguments.map { (name, value) -> fakeValueArgument(name, value) }
+        val defaults = defaultArguments.map { (name, value) -> fakeValueArgument(name, value) }
+        return proxy { method ->
+            when (method.name) {
+                "getArguments" -> args
+                "getDefaultArguments" -> defaults
+                else -> unsupported(method)
+            }
+        }
+    }
+
+    private fun fakeValueArgument(name: String, value: Any?): KSValueArgument = proxy { method ->
+        when (method.name) {
+            "getName" -> fakeName(name)
+            "getValue" -> value
+            else -> unsupported(method)
+        }
+    }
+
+    private fun fakeName(value: String): KSName = proxy { method ->
+        when (method.name) {
+            "asString" -> value
+            else -> unsupported(method)
+        }
+    }
+
+    private inline fun <reified T> proxy(crossinline handler: (Method) -> Any?): T {
+        val invocationHandler = InvocationHandler { _, method, _ -> handler(method) }
+        return Proxy.newProxyInstance(T::class.java.classLoader, arrayOf(T::class.java), invocationHandler) as T
+    }
+
+    private fun unsupported(method: Method): Nothing =
+        throw UnsupportedOperationException("Fake does not implement ${method.name}")
+}


### PR DESCRIPTION
## Summary

Builds on top of the KMP work in #219. With the multiplatform `konvert-api` annotations in place, I tried to run the processor itself against `kspCommonMainKotlinMetadata` so the mappers are generated **once** into `commonMain` (instead of running KSP per platform / copying generated files around). That surfaced several crashes specific to the metadata compilation phase, where KSP behaves differently from platform compilations. This PR fixes them.

### 1. Annotation arguments left at their default are not materialized

In `kspCommonMainKotlinMetadata`, defaulted annotation arguments are missing from `KSAnnotation.arguments`, and `KSAnnotation.defaultArguments` returns `null` for array-valued defaults (e.g. `mappings = []`). The existing `arguments.first { ... }` parsing therefore threw `NoSuchElementException`, and casts like `... as List<*>` threw NPEs.

- Added `KSAnnotation.argumentValue(name, fallback)` (explicit arg → KSP default → caller fallback).
- Routed all `AnnotationData.from(...)` parsers (`Konvert`, `KonvertTo`, `KonvertFrom`, `Konverter`, plus `Mapping`/`Konfig`) through it.

### 2. `constructorArgs`: "absent" vs explicit empty list

`constructorArgs` defaults to `[Unit::class]` (auto-detect constructor), but `constructorArgs = []` explicitly means "use the no-arg constructor". In the metadata phase these are indistinguishable by value (the default simply isn't materialized).

- Added `KSAnnotation.constructorArgClassDeclarations(name, resolver)` which only synthesizes the `[Unit]` sentinel when the argument is genuinely **absent** from `arguments`, and otherwise preserves the explicit list (including `[]`).
- This keeps `enforceUsingEmptyConstructor` working while fixing auto-detection in metadata.

### 3. Built-in converters crash resolving JVM-only types in common

Converters resolved their endpoints via `resolver.getClassDeclarationByName(...)!!`. JVM-only types (e.g. `java.math.BigInteger`, `java.util.Date`, `java.time.*`) aren't on the common/native classpath, so this returned `null` and crashed (`BaseTypeConverter#sourceType` NPE, etc.).

- Made `sourceType`/`targetType` nullable across `BaseTypeConverter` and the date/temporal/enum converters.
- `matches()` now returns `false` when an endpoint type can't be resolved in the current compilation, so the converter is simply inapplicable instead of crashing.

## Result

- Generating mappers straight into `commonMain` via `kspCommonMainKotlinMetadata` now works; downstream platform compilations (Android + iOS) consume the single generated source set. This removes the need for the Android-only-KSP + copy-into-commonMain workaround.
- Full `./gradlew test` is green (processor, converter, and all injector modules).

## Test plan

- [x] `./gradlew :processor:test :converter:test`
- [x] `./gradlew test` (all modules)
- [x] Verified a real KMP consumer compiles for both Android and iOS from the common-generated mappers

Made with [Cursor](https://cursor.com)