### PR TITLE
feat(#119): support mapping into an existing target instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### New features
+
+* New annotation `@Konverter.Target` to map into an already existing target instance instead of creating a new one [#119](https://github.com/mcarleio/konvert/issues/119)
+  ```kotlin
+  @Konverter
+  interface PersonMapper {
+      fun update(person: Person, @Konverter.Target personEntity: PersonEntity)
+  }
+
+  class Person(val name: String)
+  class PersonEntity {
+      var id: Long = 0
+      var name: String = ""
+  }
+  ```
+  generates
+  ```kotlin
+  object PersonMapperImpl : PersonMapper {
+    override fun update(person: Person, personEntity: PersonEntity) {
+      personEntity.name = person.name
+    }
+  }
+  ```
+  * as no constructor is called, only mutable properties and setters of the target are written; properties without a matching source field (like `id` above) keep their value
+  * the function may also return the type of the annotated parameter, in which case the updated instance is returned
+  * such a function is not registered as a type converter, as the target instance has to be provided by the caller
+  * `konvert.non-constructor-properties-mapping` defaults to `implicit` for these functions, so a single `@Mapping` does not disable the implicit mappings of all other matching properties
+
 ### Bug fixes
 * fix the visibility checks for what the generated extension functions can access on source and target [#288](https://github.com/mcarleio/konvert/issues/288)
 

--- a/annotations/src/main/kotlin/io/mcarle/konvert/api/Konverter.kt
+++ b/annotations/src/main/kotlin/io/mcarle/konvert/api/Konverter.kt
@@ -31,8 +31,37 @@ annotation class Konverter(
 ) {
 
     @Retention(AnnotationRetention.RUNTIME)
-    @Target(AnnotationTarget.VALUE_PARAMETER)
+    @kotlin.annotation.Target(AnnotationTarget.VALUE_PARAMETER)
     annotation class Source
+
+    /**
+     * Annotate a parameter of a function inside a `@Konverter` annotated interface to map into that already existing
+     * instance instead of creating a new instance of the target type.
+     *
+     * Example:
+     * ```kotlin
+     * class Source(val source: Int)
+     * class Target { var target: String = "" }
+     *
+     * @Konverter
+     * interface Mapper {
+     *   @Konvert(mappings = [Mapping(source="source", target="target")])
+     *   fun update(source: Source, @Konverter.Target target: Target)
+     * }
+     * ```
+     *
+     * This will generate an implementation, which sets the properties on the passed instance:
+     * ```kotlin
+     * object MapperImpl : Mapper {
+     *      override fun update(source: Source, target: Target) {
+     *          target.target = source.source.toString()
+     *      }
+     * }
+     * ```
+     */
+    @Retention(AnnotationRetention.RUNTIME)
+    @kotlin.annotation.Target(AnnotationTarget.VALUE_PARAMETER)
+    annotation class Target
 
     /**
      * This object can be used to load the generated class of an interface, which is annotated with `@Konverter`.

--- a/docs/annotations/konverter-target.adoc
+++ b/docs/annotations/konverter-target.adoc
@@ -1,0 +1,72 @@
+:page-title: @Konverter.Target
+:page-parent: @Konverter
+:page-grand_parent: Annotations
+
+= @Konverter.Target
+
+The annotation `@Konverter.Target` is only being processed in abstract functions in interfaces annotated with xref:konverter.adoc[`@Konverter`].
+
+It marks a parameter as the target instance to map into. Konvert then sets the properties on that already existing
+instance instead of creating a new one, which is useful whenever you do not control the creation of the target, e.g.
+when updating an entity loaded from a database.
+
+[source,kotlin]
+----
+@Konverter
+interface PersonMapper {
+    fun update(person: Person, @Konverter.Target personEntity: PersonEntity)
+}
+
+class Person(val name: String)
+class PersonEntity {
+    var id: Long = 0
+    var name: String = ""
+}
+----
+
+This will generate
+
+[source,kotlin]
+----
+object PersonMapperImpl : PersonMapper {
+  override fun update(person: Person, personEntity: PersonEntity) {
+    personEntity.name = person.name
+  }
+}
+----
+
+As no constructor is called, only mutable properties (and setters) of the target are written. Properties without a
+matching source field — like `id` in the example above — keep their current value.
+
+The function may either return nothing or the type of the `@Konverter.Target` annotated parameter. In the latter case,
+the generated code returns the updated instance:
+
+[source,kotlin]
+----
+@Konverter
+interface PersonMapper {
+    fun update(person: Person, @Konverter.Target personEntity: PersonEntity): PersonEntity
+}
+----
+
+[source,kotlin]
+----
+object PersonMapperImpl : PersonMapper {
+  override fun update(person: Person, personEntity: PersonEntity): PersonEntity {
+    personEntity.name = person.name
+    return personEntity
+  }
+}
+----
+
+If the source parameter is nullable, the target instance is left untouched for a `null` source.
+
+== Differences to the other mapping functions
+
+* Such a function is *not* registered as a type converter, as callers have to provide the target instance themselves.
+  Therefore it is neither used implicitly for nested mappings nor exported via `@GeneratedKonverter`.
+* The xref:../options/index.adoc[`konvert.non-constructor-properties-mapping`] option
+  defaults to `implicit` for these functions: when mapping into an existing instance, every target property is a
+  non-constructor property, so defining a single xref:mapping.adoc[`@Mapping`] does not disable the implicit mappings of
+  all other matching properties. The other values of the option are still respected.
+* Use `@Mapping(target = "...", ignore = true)` to exclude a target property from being written.

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/CodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/CodeGenerator.kt
@@ -36,7 +36,7 @@ class CodeGenerator constructor(
         visibilityContext: MappingVisibilityContext,
         additionalSourceParameters: List<KSValueParameter>
     ): CodeBlock {
-        if (context.paramName != null && mappings.isEmpty()) {
+        if (context.targetParamName == null && context.paramName != null && mappings.isEmpty()) {
             val existingTypeConverter = TypeConverterRegistry
                 .firstOrNull {
                     it.matches(context.source, context.target) && it !is AnnotatedConverter
@@ -60,21 +60,29 @@ class CodeGenerator constructor(
             sourceDataList = sourceDataList
         )
 
-        val constructor = ConstructorResolver.determineConstructor(
-            targetData = targetData,
-            sourceProperties = sourceProperties,
-            constructorTypes = enforcedConstructorTypes
-        )
+        // when mapping into an already existing target instance, no constructor is called at all
+        val constructor = if (context.targetParamName == null) {
+            ConstructorResolver.determineConstructor(
+                targetData = targetData,
+                sourceProperties = sourceProperties,
+                constructorTypes = enforcedConstructorTypes
+            )
+        } else {
+            null
+        }
 
-        val constructorParameters = constructor.parameters
+        val constructorParameters = constructor?.parameters ?: emptyList()
 
-        verifyAvailableMappingsForConstructorParameters(sourceProperties, constructorParameters)
+        if (constructor != null) {
+            verifyAvailableMappingsForConstructorParameters(sourceProperties, constructorParameters)
+        }
 
         verifyTargetExists(mappings, constructorParameters, targetData.varProperties, targetData.setter)
 
         val effectiveNonConstructorPropertiesMappingMode = determineNonConstructorPropertiesMappingMode(
             targetData,
-            sourceProperties
+            sourceProperties,
+            context
         )
 
         val variablesWithoutConstructorParameters = obtainTargetNonConstructorProperties(
@@ -92,13 +100,26 @@ class CodeGenerator constructor(
             effectiveNonConstructorPropertiesMappingMode
         )
 
-        return MappingCodeGenerator(logger).generateMappingCode(
-            context,
-            sourceProperties.sortedByDescending { it.isBasedOnAnnotation },
-            constructor,
-            variablesWithoutConstructorParameters.map { it.property },
-            remainingSetters.toList()
-        )
+        val mappingCodeGenerator = MappingCodeGenerator(logger)
+        val orderedSourceProperties = sourceProperties.sortedByDescending { it.isBasedOnAnnotation }
+        val targetProperties = variablesWithoutConstructorParameters.map { it.property }
+
+        return if (constructor == null) {
+            mappingCodeGenerator.generateUpdateCode(
+                context,
+                orderedSourceProperties,
+                targetProperties,
+                remainingSetters.toList()
+            )
+        } else {
+            mappingCodeGenerator.generateMappingCode(
+                context,
+                orderedSourceProperties,
+                constructor,
+                targetProperties,
+                remainingSetters.toList()
+            )
+        }
     }
 
     private fun verifyTargetExists(
@@ -128,9 +149,22 @@ class CodeGenerator constructor(
     private fun determineNonConstructorPropertiesMappingMode(
         targetData: TargetDataExtractionStrategy.TargetData,
         sourceProperties: List<PropertyMappingInfo>,
+        context: MappingContext,
     ): NonConstructorPropertiesMapping {
         return when (val value = Configuration.nonConstructorPropertiesMapping) {
             NonConstructorPropertiesMapping.AUTO -> {
+                if (context.targetParamName != null) {
+                    // when mapping into an existing target instance, every target property is a non-constructor
+                    // property. Restricting them to the annotated ones would ignore all matching properties, so
+                    // defining a single mapping must not disable the implicit ones.
+                    return NonConstructorPropertiesMapping.IMPLICIT.also {
+                        logger.logging(
+                            "${NON_CONSTRUCTOR_PROPERTIES_MAPPING_OPTION.key} resolved to: $it",
+                            targetData.classDeclaration
+                        )
+                    }
+                }
+
                 val userDefinedProperties = sourceProperties.filter { it.isBasedOnAnnotation }
 
                 return if (userDefinedProperties.none { !it.ignore }) {

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/MappingCodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/MappingCodeGenerator.kt
@@ -76,6 +76,37 @@ class MappingCodeGenerator constructor(
         }
     }
 
+    /**
+     * Generates the code to map into an already existing target instance, which is passed as the
+     * @[io.mcarle.konvert.api.Konverter.Target] annotated parameter.
+     */
+    fun generateUpdateCode(
+        context: MappingContext,
+        sourceProperties: List<PropertyMappingInfo>,
+        targetProperties: List<KSPropertyDeclaration>,
+        targetSetters: List<TargetSetter>
+    ): CodeBlock {
+        val targetParamName = context.targetParamName!!
+        val assignmentCode = if (noTargetOrAllIgnored(sourceProperties, targetProperties, targetSetters)) {
+            CodeBlock.of("")
+        } else {
+            propertySettingCode(targetProperties, targetSetters, sourceProperties, targetParamName)
+        }
+
+        // a null source has nothing to map, so the existing target instance is left untouched
+        val guardedAssignmentCode = if (context.source.isNullable() && !assignmentCode.isEmpty()) {
+            CodeBlock.of("${context.paramName!!}?.let·{\n⇥%L⇤\n}", assignmentCode)
+        } else {
+            assignmentCode
+        }
+
+        if (!context.returnsTargetParam) return guardedAssignmentCode
+
+        return listOf(guardedAssignmentCode, CodeBlock.of("return·$targetParamName"))
+            .filterNot { it.isEmpty() }
+            .joinToCode("\n")
+    }
+
     private fun constructorCode(
         className: String?,
         classDeclaration: KSClassDeclaration,

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/MappingContext.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/codegen/MappingContext.kt
@@ -10,4 +10,12 @@ data class MappingContext constructor(
     val target: KSType,
     val paramName: String?,
     val targetClassImportName: String?,
+    /**
+     * When set, the mapping writes into that already existing target instance instead of creating a new one.
+     */
+    val targetParamName: String? = null,
+    /**
+     * When true, the generated code returns the updated target instance.
+     */
+    val returnsTargetParam: Boolean = false,
 )

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
@@ -23,7 +23,12 @@ class KonvertData constructor(
     val sourceTypeReference: KSTypeReference,
     val targetTypeReference: KSTypeReference,
     val mapKSFunctionDeclaration: KSFunctionDeclaration,
-    val additionalParameters: List<KSValueParameter>
+    val additionalParameters: List<KSValueParameter>,
+    val targetParameter: KSValueParameter? = null,
+    /**
+     * True, if the function both takes a @[io.mcarle.konvert.api.Konverter.Target] annotated parameter and returns it.
+     */
+    val returnsTargetParameter: Boolean = false
 ) {
 
     val sourceType: KSType = sourceTypeReference.resolve()
@@ -31,7 +36,15 @@ class KonvertData constructor(
     val targetType: KSType = targetTypeReference.resolve()
     val targetClassDeclaration: KSClassDeclaration = targetType.classDeclaration()!!
     val mapFunctionName: String = mapKSFunctionDeclaration.simpleName.asString()
-    val paramName: String = (mapKSFunctionDeclaration.parameters - additionalParameters).first().name!!.asString()
+
+    /**
+     * The name of the @[io.mcarle.konvert.api.Konverter.Target] annotated parameter, if the mapping writes into an
+     * already existing target instance instead of creating a new one.
+     */
+    val targetParamName: String? = targetParameter?.name?.asString()
+    val mapsIntoExistingTarget: Boolean = targetParameter != null
+    val paramName: String =
+        (mapKSFunctionDeclaration.parameters - additionalParameters - listOfNotNull(targetParameter)).first().name!!.asString()
 
     val priority = annotationData.priority
 

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonvertData.kt
@@ -41,7 +41,7 @@ class KonvertData constructor(
      * The name of the @[io.mcarle.konvert.api.Konverter.Target] annotated parameter, if the mapping writes into an
      * already existing target instance instead of creating a new one.
      */
-    val targetParamName: String? = targetParameter?.name?.asString()
+    val targetParamName: String? = targetParameter?.let { it.name!!.asString() }
     val mapsIntoExistingTarget: Boolean = targetParameter != null
     val paramName: String =
         (mapKSFunctionDeclaration.parameters - additionalParameters - listOfNotNull(targetParameter)).first().name!!.asString()

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
@@ -65,7 +65,11 @@ object KonverterCodeGenerator {
                         codeBuilder.addFunction(
                             funBuilder = FunSpec.builder(konvertData.mapFunctionName)
                                 .addModifiers(KModifier.OVERRIDE)
-                                .returns(konvertData.targetTypeReference.toTypeName())
+                                // when mapping into an existing target instance, the function may return Unit
+                                .returns(
+                                    konvertData.mapKSFunctionDeclaration.returnType?.toTypeName()
+                                        ?: konvertData.targetTypeReference.toTypeName()
+                                )
                                 .addParameters(konvertData.mapKSFunctionDeclaration.parameters.map {
                                     val builder = ParameterSpec.builder(
                                         name = it.name!!.asString(),
@@ -133,6 +137,8 @@ object KonverterCodeGenerator {
                     target = konvertData.targetType,
                     paramName = konvertData.paramName,
                     targetClassImportName = targetClassImportName,
+                    targetParamName = konvertData.targetParamName,
+                    returnsTargetParam = konvertData.returnsTargetParameter,
                 ),
                 visibilityContext = MappingVisibilityContext.Declaration(konvertData.mapKSFunctionDeclaration),
                 additionalSourceParameters = konvertData.additionalParameters

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterCodeGenerator.kt
@@ -9,6 +9,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.ksp.toTypeName
 import io.mcarle.konvert.api.Konverter
 import io.mcarle.konvert.converter.api.config.Configuration
@@ -67,8 +68,11 @@ object KonverterCodeGenerator {
                                 .addModifiers(KModifier.OVERRIDE)
                                 // when mapping into an existing target instance, the function may return Unit
                                 .returns(
-                                    konvertData.mapKSFunctionDeclaration.returnType?.toTypeName()
-                                        ?: konvertData.targetTypeReference.toTypeName()
+                                    if (konvertData.mapsIntoExistingTarget && !konvertData.returnsTargetParameter) {
+                                        UNIT
+                                    } else {
+                                        konvertData.targetTypeReference.toTypeName()
+                                    }
                                 )
                                 .addParameters(konvertData.mapKSFunctionDeclaration.parameters.map {
                                     val builder = ParameterSpec.builder(

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterData.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterData.kt
@@ -18,7 +18,9 @@ class KonverterData constructor(
 
     override fun toTypeConverters(): List<AnnotatedConverter> {
         return withIsolatedConfiguration(annotationData.options) {
-            konvertData.map {
+            // functions mapping into an existing target instance cannot be used as a type converter, as they require
+            // the caller to provide that instance
+            konvertData.filterNot { it.mapsIntoExistingTarget }.map {
                 KonvertTypeConverter(
                     priority = it.priority,
                     alreadyGenerated = false,

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
@@ -119,7 +119,7 @@ object KonverterDataCollector {
                         sourceTypeReference = source,
                         targetTypeReference = target,
                         mapKSFunctionDeclaration = it,
-                        additionalParameters = determineAdditionalParams(it, sourceValueParameter, targetValueParameter),
+                        additionalParameters = determineAdditionalParams(it, sourceValueParameter),
                         targetParameter = targetValueParameter,
                         returnsTargetParameter = targetValueParameter != null && returnedTarget != null
                     )
@@ -168,14 +168,12 @@ object KonverterDataCollector {
     @OptIn(KspExperimental::class)
     private fun determineAdditionalParams(
         function: KSFunctionDeclaration,
-        sourceParam: KSValueParameter?,
-        targetParam: KSValueParameter?
+        sourceParam: KSValueParameter?
     ): List<KSValueParameter> {
         return function.parameters
             .filterNot { it.isAnnotationPresent(Konverter.Source::class) }
             .filterNot { it.isAnnotationPresent(Konverter.Target::class) }
             .filterNot { it == sourceParam }
-            .filterNot { it == targetParam }
     }
 
 }

--- a/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
+++ b/processor/src/main/kotlin/io/mcarle/konvert/processor/konvert/KonverterDataCollector.kt
@@ -60,13 +60,35 @@ object KonverterDataCollector {
                     return@mapNotNull null
                 }
 
-                val sourceValueParameter = determineSourceParam(it, logger)
+                val targetValueParameters = determineTargetParams(it)
+                if (targetValueParameters.size > 1) {
+                    logger.error(
+                        "Ignored function as multiple parameters were annotated with " +
+                            "@${Konverter::class.simpleName}.${Konverter.Target::class.simpleName}",
+                        it
+                    )
+                    return@mapNotNull null
+                }
+                val targetValueParameter = targetValueParameters.firstOrNull()
+                val sourceValueParameter = determineSourceParam(it, targetValueParameter, logger)
                 val source = sourceValueParameter?.type
-                val target = it.returnType?.let { returnType ->
+                val returnedTarget = it.returnType?.let { returnType ->
                     if (returnType.resolve().declaration == resolver.getClassDeclarationByName<Unit>()) {
                         null
                     } else {
                         returnType
+                    }
+                }
+                // a @Konverter.Target annotated parameter defines the target instance to map into, so the function
+                // does not need to return the target
+                val target = targetValueParameter?.type ?: returnedTarget
+
+                if (targetValueParameter != null && returnedTarget != null) {
+                    // the only sensible thing such a function can return is the updated target instance itself
+                    check(returnedTarget.resolve() == targetValueParameter.type.resolve()) {
+                        "${Konvert::class.simpleName} annotated function must return the type of its " +
+                            "@${Konverter::class.simpleName}.${Konverter.Target::class.simpleName} annotated parameter " +
+                            "or nothing at all: ${it.qualifiedName?.asString() ?: it}"
                     }
                 }
 
@@ -83,7 +105,9 @@ object KonverterDataCollector {
                     check(source != null && target != null) {
                         "${Konvert::class.simpleName} annotated function must have exactly one source parameter (either single " +
                             "parameter or annotated with @${Konverter::class.simpleName}.${Konverter.Source::class.simpleName}) " +
-                            "and must have a return type: ${it.qualifiedName?.asString() ?: it}"
+                            "and must either have a return type or a parameter annotated with " +
+                            "@${Konverter::class.simpleName}.${Konverter.Target::class.simpleName}: " +
+                            "${it.qualifiedName?.asString() ?: it}"
                     }
                 }
 
@@ -95,7 +119,9 @@ object KonverterDataCollector {
                         sourceTypeReference = source,
                         targetTypeReference = target,
                         mapKSFunctionDeclaration = it,
-                        additionalParameters = determineAdditionalParams(it, sourceValueParameter)
+                        additionalParameters = determineAdditionalParams(it, sourceValueParameter, targetValueParameter),
+                        targetParameter = targetValueParameter,
+                        returnsTargetParameter = targetValueParameter != null && returnedTarget != null
                     )
                 } else {
                     if (annotation != null) {
@@ -109,8 +135,17 @@ object KonverterDataCollector {
     }
 
     @OptIn(KspExperimental::class)
-    private fun determineSourceParam(function: KSFunctionDeclaration, logger: KSPLogger): KSValueParameter? {
-        val parameters = function.parameters
+    private fun determineTargetParams(function: KSFunctionDeclaration): List<KSValueParameter> {
+        return function.parameters.filter { it.isAnnotationPresent(Konverter.Target::class) }
+    }
+
+    @OptIn(KspExperimental::class)
+    private fun determineSourceParam(
+        function: KSFunctionDeclaration,
+        targetParam: KSValueParameter?,
+        logger: KSPLogger
+    ): KSValueParameter? {
+        val parameters = function.parameters - listOfNotNull(targetParam)
         return when {
             parameters.isEmpty() -> null
             parameters.size > 1 -> {
@@ -131,10 +166,16 @@ object KonverterDataCollector {
     }
 
     @OptIn(KspExperimental::class)
-    private fun determineAdditionalParams(function: KSFunctionDeclaration, sourceParam: KSValueParameter?): List<KSValueParameter> {
+    private fun determineAdditionalParams(
+        function: KSFunctionDeclaration,
+        sourceParam: KSValueParameter?,
+        targetParam: KSValueParameter?
+    ): List<KSValueParameter> {
         return function.parameters
             .filterNot { it.isAnnotationPresent(Konverter.Source::class) }
+            .filterNot { it.isAnnotationPresent(Konverter.Target::class) }
             .filterNot { it == sourceParam }
+            .filterNot { it == targetParam }
     }
 
 }

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonvertITest.kt
@@ -1357,7 +1357,7 @@ interface Mapper {
 
         assertContains(
             compilationResult.messages,
-            "Konvert annotated function must have exactly one source parameter (either single parameter or annotated with @Konverter.Source) and must have a return type: Mapper.toTarget"
+            "Konvert annotated function must have exactly one source parameter (either single parameter or annotated with @Konverter.Source) and must either have a return type or a parameter annotated with @Konverter.Target: Mapper.toTarget"
         )
     }
 

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonverterTargetITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonverterTargetITest.kt
@@ -1,0 +1,347 @@
+package io.mcarle.konvert.processor.konvert
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.SourceFile
+import io.mcarle.konvert.converter.IntToStringConverter
+import io.mcarle.konvert.converter.SameTypeConverter
+import io.mcarle.konvert.converter.api.TypeConverterRegistry
+import io.mcarle.konvert.processor.KonverterITest
+import io.mcarle.konvert.processor.generatedSourceFor
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCompilerApi::class)
+class KonverterTargetITest : KonverterITest() {
+
+    @Test
+    fun mapIntoExistingTargetInstance() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+
+class SourceClass(
+    val property: String
+)
+class TargetClass {
+    var property: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun update(@Konverter.Source source: SourceClass, @Konverter.Target target: TargetClass)
+}
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertSourceEquals(
+            """
+            public object MapperImpl : Mapper {
+              override fun update(source: SourceClass, target: TargetClass) {
+                target.property = source.property
+              }
+            }
+            """.trimIndent(),
+            mapperCode
+        )
+    }
+
+    @Test
+    fun returnTheUpdatedTargetInstance() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+
+class SourceClass(
+    val property: String
+)
+class TargetClass {
+    var property: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun update(source: SourceClass, @Konverter.Target target: TargetClass): TargetClass
+}
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertSourceEquals(
+            """
+            public object MapperImpl : Mapper {
+              override fun update(source: SourceClass, target: TargetClass): TargetClass {
+                target.property = source.property
+                return target
+              }
+            }
+            """.trimIndent(),
+            mapperCode
+        )
+    }
+
+    @Test
+    fun keepIgnoredTargetPropertyUntouchedAndStillMapTheRemainingProperties() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
+
+class SourceClass(
+    val property: String,
+    val other: String
+)
+class TargetClass {
+    var id: Long = 0
+    var property: String = ""
+    var other: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert(mappings = [
+        Mapping(target = "id", ignore = true),
+        Mapping(target = "other", constant = "\"fixed\"")
+    ])
+    fun update(source: SourceClass, @Konverter.Target target: TargetClass)
+}
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertSourceEquals(
+            """
+            public object MapperImpl : Mapper {
+              override fun update(source: SourceClass, target: TargetClass) {
+                target.property = source.property
+                target.other = "fixed"
+              }
+            }
+            """.trimIndent(),
+            mapperCode
+        )
+    }
+
+    @Test
+    fun doNotTouchTheTargetInstanceForANullSource() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+
+class SourceClass(
+    val property: String
+)
+class TargetClass {
+    var property: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun update(source: SourceClass?, @Konverter.Target target: TargetClass)
+}
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertSourceEquals(
+            """
+            public object MapperImpl : Mapper {
+              override fun update(source: SourceClass?, target: TargetClass) {
+                source?.let {
+                  target.property = source.property
+                }
+              }
+            }
+            """.trimIndent(),
+            mapperCode
+        )
+    }
+
+    @Test
+    fun doNotRegisterUpdateFunctionAsTypeConverter() {
+        compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+
+class SourceClass(
+    val property: String
+)
+class TargetClass {
+    var property: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun update(source: SourceClass, @Konverter.Target target: TargetClass)
+}
+                """.trimIndent()
+            )
+        )
+
+        val konverterOfUpdateFunction = TypeConverterRegistry
+            .filterIsInstance<KonvertTypeConverter>()
+            .firstOrNull { it.mapFunctionName == "update" }
+        assertNull(
+            konverterOfUpdateFunction,
+            "An update function must not be registered as a type converter, as it needs a target instance"
+        )
+    }
+
+    @Test
+    fun useExpressionsConvertersAndAdditionalParametersWhenUpdating() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter(), IntToStringConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
+
+class SourceClass(
+    val number: Int,
+    val text: String
+)
+class TargetClass {
+    var number: String = ""
+    var text: String = ""
+    var addition: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert(mappings = [Mapping(target = "text", expression = "it.text.uppercase()")])
+    fun update(@Konverter.Source source: SourceClass, @Konverter.Target target: TargetClass, addition: String)
+}
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertSourceEquals(
+            """
+            import kotlin.String
+
+            public object MapperImpl : Mapper {
+              override fun update(
+                source: SourceClass,
+                target: TargetClass,
+                addition: String,
+              ) {
+                target.number = source.number.toString()
+                target.text = source.let { it.text.uppercase() }
+                target.addition = addition
+              }
+            }
+            """.trimIndent(),
+            mapperCode
+        )
+    }
+
+    @Test
+    fun failOnMultipleTargetAnnotatedParameters() {
+        val (_, compilationResult) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.COMPILATION_ERROR,
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+
+class SourceClass(
+    val property: String
+)
+class TargetClass {
+    var property: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun update(
+        source: SourceClass,
+        @Konverter.Target target: TargetClass,
+        @Konverter.Target otherTarget: TargetClass
+    )
+}
+                """.trimIndent()
+            )
+        )
+
+        assertContains(compilationResult.messages, "multiple parameters were annotated with @Konverter.Target")
+    }
+
+    @Test
+    fun failOnReturnTypeDifferentFromTargetParameterType() {
+        val (_, compilationResult) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            expectResultCode = KotlinCompilation.ExitCode.INTERNAL_ERROR,
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+
+class SourceClass(
+    val property: String
+)
+class TargetClass {
+    var property: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert
+    fun update(source: SourceClass, @Konverter.Target target: TargetClass): String
+}
+                """.trimIndent()
+            )
+        )
+
+        assertContains(compilationResult.messages, "must return the type of its @Konverter.Target annotated parameter")
+    }
+}

--- a/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonverterTargetITest.kt
+++ b/processor/src/test/kotlin/io/mcarle/konvert/processor/konvert/KonverterTargetITest.kt
@@ -280,6 +280,89 @@ interface Mapper {
     }
 
     @Test
+    fun generateNoAssignmentsWhenAllTargetPropertiesAreIgnored() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
+
+class SourceClass(
+    val property: String
+)
+class TargetClass {
+    var property: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert(mappings = [Mapping(target = "property", ignore = true)])
+    fun update(source: SourceClass?, @Konverter.Target target: TargetClass)
+}
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertSourceEquals(
+            """
+            public object MapperImpl : Mapper {
+              override fun update(source: SourceClass?, target: TargetClass) {
+              }
+            }
+            """.trimIndent(),
+            mapperCode
+        )
+    }
+
+    @Test
+    fun returnTheTargetInstanceWhenAllTargetPropertiesAreIgnored() {
+        val (compilation) = compileWith(
+            enabledConverters = listOf(SameTypeConverter()),
+            code = SourceFile.kotlin(
+                name = "TestCode.kt",
+                contents =
+                    """
+import io.mcarle.konvert.api.Konvert
+import io.mcarle.konvert.api.Konverter
+import io.mcarle.konvert.api.Mapping
+
+class SourceClass(
+    val property: String
+)
+class TargetClass {
+    var property: String = ""
+}
+
+@Konverter
+interface Mapper {
+    @Konvert(mappings = [Mapping(target = "property", ignore = true)])
+    fun update(source: SourceClass, @Konverter.Target target: TargetClass): TargetClass
+}
+                """.trimIndent()
+            )
+        )
+        val mapperCode = compilation.generatedSourceFor("MapperKonverter.kt")
+        println(mapperCode)
+
+        assertSourceEquals(
+            """
+            public object MapperImpl : Mapper {
+              override fun update(source: SourceClass, target: TargetClass): TargetClass {
+                return target
+              }
+            }
+            """.trimIndent(),
+            mapperCode
+        )
+    }
+
+    @Test
     fun failOnMultipleTargetAnnotatedParameters() {
         val (_, compilationResult) = compileWith(
             enabledConverters = listOf(SameTypeConverter()),


### PR DESCRIPTION
Implements #119: map into an already existing target instance instead of always constructing a new one.

  ## API

  A new nested annotation `@Konverter.Target` marks the parameter to map into:
  
  ```kotlin
  @Konverter
  interface PersonMapper {
      fun update(person: Person, @Konverter.Target personEntity: PersonEntity)
  }
  
  class Person(val name: String)
  class PersonEntity {
      var id: Long = 0
      var name: String = ""
  }
  ```
  
  generates

  ```kotlin
  public object PersonMapperImpl : PersonMapper {
    override fun update(person: Person, personEntity: PersonEntity) {
      personEntity.name = person.name
    }
  }
  ```
  
  No constructor is called, so only mutable properties and setters are written and target properties without a matching source field (`id` above) keep their value.

  ## Behaviour decisions

  Each of these is pinned by a test, and I am happy to change any of them:
  
  * **Return type** — the function may return `Unit` or the type of the annotated parameter. In the latter case the generated code ends with `return <param>`. Any other return type fails with a speaking
  error.
  * **Nullable source** — the assignments are wrapped in `source?.let { … }`, so a `null` source leaves the existing target untouched.
  * **Not a type converter** — such a function is not registered in the `TypeConverterRegistry`, since the caller has to supply the target instance. It is therefore not used implicitly for nested mappings.
  (`@GeneratedKonverter` was already skipped for multi-parameter functions.)
  * **`konvert.non-constructor-properties-mapping`** — `AUTO` resolves to `IMPLICIT` for these functions. When mapping into an existing instance every target property is a non-constructor property, so with
  `EXPLICIT` a single `@Mapping` would silently disable the implicit mapping of all other matching properties. The explicitly configured values are still respected.
  * **Multiple `@Konverter.Target` parameters** — reported via `logger.error` and the function is skipped, mirroring how multiple `@Konverter.Source` parameters are handled.

  ## Notable implementation detail

  Naming the nested annotation `Target` shadows `kotlin.Target` inside the `Konverter` body, so the existing annotation on `Konverter.Source` had to be qualified as `@kotlin.annotation.Target(…)`. If you
  would rather avoid that, I can rename the new annotation (e.g. `@Konverter.MappingTarget`) — happy to follow your preference.

  ## Tests

  New `KonverterTargetITest` with 8 cases (basic update, fluent return, `ignore` plus implicit mappings, null source, no converter registration, expressions/converters/additional parameters, and the two
  error cases).

  One existing assertion in `KonvertITest` was updated, because the "must have a return type" error message now also mentions `@Konverter.Target`.
  
  `./gradlew check` passes locally (263 processor tests, 0 failures).

  ## Not included

  Deliberately out of scope, happy to add if you want them in this PR:
  
  * `@KonvertTo` / `@KonvertFrom` support — this is `@Konverter`-only.
  * Using an update function as a nested converter for a mutable sub-property (MapStruct does this).
  * A test for Java-origin setters as update target (the existing setter code path is reused, but untested for this case).